### PR TITLE
[API-2954] Drop - Do not simulate getting out of bonded denom

### DIFF
--- a/contracts/adapters/swap/drop/src/contract.rs
+++ b/contracts/adapters/swap/drop/src/contract.rs
@@ -314,7 +314,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     .map_err(From::from)
 }
 
-fn get_opposite_denom_in(denom_in: &str, remote_denom: &str, bonded_denom: &str) -> ContractResult<String> {
+fn get_opposite_denom_in(
+    denom_in: &str,
+    remote_denom: &str,
+    bonded_denom: &str,
+) -> ContractResult<String> {
     match denom_in {
         // if doing an 'in' query, only allow for simulating putting the remote denom in
         denom_in if denom_in == remote_denom => Ok(bonded_denom.to_string()),
@@ -323,7 +327,11 @@ fn get_opposite_denom_in(denom_in: &str, remote_denom: &str, bonded_denom: &str)
     }
 }
 
-fn get_opposite_denom_out(denom_out: &str, remote_denom: &str, bonded_denom: &str) -> ContractResult<String> {
+fn get_opposite_denom_out(
+    denom_out: &str,
+    remote_denom: &str,
+    bonded_denom: &str,
+) -> ContractResult<String> {
     match denom_out {
         // if doing an 'out' query, only allow for simulating getting the bonded denom out
         denom_out if denom_out == remote_denom => Err(ContractError::UnsupportedDenom),

--- a/contracts/adapters/swap/drop/src/contract.rs
+++ b/contracts/adapters/swap/drop/src/contract.rs
@@ -317,7 +317,6 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
 fn get_opposite_denom(denom: &str, remote_denom: &str, bonded_denom: &str) -> String {
     match denom {
         denom if denom == remote_denom => bonded_denom.to_string(),
-        denom if denom == bonded_denom => remote_denom.to_string(),
         _ => unimplemented!(),
     }
 }

--- a/contracts/adapters/swap/drop/src/contract.rs
+++ b/contracts/adapters/swap/drop/src/contract.rs
@@ -207,7 +207,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
         QueryMsg::SimulateSwapExactAssetIn { asset_in, .. } => {
             let asset_out_denom =
-                get_opposite_denom(asset_in.denom(), &remote_denom, &bonded_denom);
+                get_opposite_denom_in(asset_in.denom(), &remote_denom, &bonded_denom)?;
 
             let exchange_rate = get_exchange_rate(deps)?;
 
@@ -218,7 +218,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         }
         QueryMsg::SimulateSwapExactAssetOut { asset_out, .. } => {
             let asset_in_denom =
-                get_opposite_denom(asset_out.denom(), &remote_denom, &bonded_denom);
+                get_opposite_denom_out(asset_out.denom(), &remote_denom, &bonded_denom)?;
 
             let exchange_rate = get_exchange_rate(deps)?;
 
@@ -233,7 +233,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
             ..
         } => {
             let asset_out_denom =
-                get_opposite_denom(asset_in.denom(), &remote_denom, &bonded_denom);
+                get_opposite_denom_in(asset_in.denom(), &remote_denom, &bonded_denom)?;
 
             let exchange_rate = get_exchange_rate(deps)?;
 
@@ -257,7 +257,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
             ..
         } => {
             let asset_in_denom =
-                get_opposite_denom(asset_out.denom(), &remote_denom, &bonded_denom);
+                get_opposite_denom_out(asset_out.denom(), &remote_denom, &bonded_denom)?;
 
             let exchange_rate = get_exchange_rate(deps)?;
 
@@ -277,7 +277,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         }
         QueryMsg::SimulateSmartSwapExactAssetIn { asset_in, .. } => {
             let asset_out_denom =
-                get_opposite_denom(asset_in.denom(), &remote_denom, &bonded_denom);
+                get_opposite_denom_in(asset_in.denom(), &remote_denom, &bonded_denom)?;
 
             let exchange_rate = get_exchange_rate(deps)?;
 
@@ -292,7 +292,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
             ..
         } => {
             let asset_out_denom =
-                get_opposite_denom(asset_in.denom(), &remote_denom, &bonded_denom);
+                get_opposite_denom_in(asset_in.denom(), &remote_denom, &bonded_denom)?;
 
             let exchange_rate = get_exchange_rate(deps)?;
 
@@ -314,9 +314,20 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     .map_err(From::from)
 }
 
-fn get_opposite_denom(denom: &str, remote_denom: &str, bonded_denom: &str) -> String {
-    match denom {
-        denom if denom == remote_denom => bonded_denom.to_string(),
+fn get_opposite_denom_in(denom_in: &str, remote_denom: &str, bonded_denom: &str) -> ContractResult<String> {
+    match denom_in {
+        // if doing an 'in' query, only allow for simulating putting the remote denom in
+        denom_in if denom_in == remote_denom => Ok(bonded_denom.to_string()),
+        denom_in if denom_in == bonded_denom => Err(ContractError::UnsupportedDenom),
+        _ => unimplemented!(),
+    }
+}
+
+fn get_opposite_denom_out(denom_out: &str, remote_denom: &str, bonded_denom: &str) -> ContractResult<String> {
+    match denom_out {
+        // if doing an 'out' query, only allow for simulating getting the bonded denom out
+        denom_out if denom_out == remote_denom => Err(ContractError::UnsupportedDenom),
+        denom_out if denom_out == bonded_denom => Ok(remote_denom.to_string()),
         _ => unimplemented!(),
     }
 }

--- a/contracts/adapters/swap/drop/tests/test_queries.rs
+++ b/contracts/adapters/swap/drop/tests/test_queries.rs
@@ -6,7 +6,8 @@ use cosmwasm_std::{
 // use lido_satellite::msg::ExecuteMsg as LidoSatelliteExecuteMsg;
 use skip::{asset::Asset, swap::QueryMsg};
 use skip_go_swap_adapter_drop::{
-    error::ContractResult, error::ContractError,
+    error::ContractError,
+    error::ContractResult,
     state::{DROP_CORE_CONTRACT_ADDRESS, FACTORY_BONDED_DENOM, IBC_REMOTE_DENOM},
 };
 use test_case::test_case;
@@ -255,8 +256,7 @@ fn test_queries(params: Params) -> ContractResult<()> {
                 params.expected_error.is_some(),
                 "expected test to succeed, but it errored with {:?}",
                 err
-            ); 
-            
+            );
             // Assert the error is correct
             assert_eq!(err, params.expected_error.unwrap());
         }


### PR DESCRIPTION
For `SimulateSwapExactAssetIn` simulations, do not allow for simulations where the `AssetIn` is the `bonded_denom`. For `SimulateSwapExactAssetOut` simulations, do not allow for simulations where the `AssetOut` is the `remote_denom`.