### PR TITLE
Add Hyperlane Transfer Action Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,7 +1841,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "hpl-interface",
- "ibc-proto",
  "prost 0.11.9",
  "serde-cw-value",
  "serde-json-wasm 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-storage"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66de2ab9db04757bcedef2b5984fbe536903ada4a8a9766717a4a71197ef34f6"
+dependencies = [
+ "cosmwasm-std",
+ "serde",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1102,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hpl-interface"
+version = "0.0.6"
+source = "git+https://github.com/many-things/cw-hyperlane.git?branch=main#89d3943ee997d6da9b13fc3599eb62024b3bee67"
+dependencies = [
+ "bech32",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
+ "cw20 1.1.2",
+ "cw20-base",
+ "ripemd",
+ "schemars",
+ "serde",
+ "sha2 0.10.8",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
 name = "ibc-proto"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1195,15 @@ dependencies = [
  "once_cell",
  "sha2 0.10.8",
  "signature",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1572,6 +1612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1780,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1826,25 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
+ "skip",
+ "test-case",
+ "thiserror",
+]
+
+[[package]]
+name = "skip-go-hyperlane-adapter"
+version = "0.3.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
+ "hpl-interface",
+ "ibc-proto",
+ "prost 0.11.9",
+ "serde-cw-value",
+ "serde-json-wasm 1.0.1",
  "skip",
  "test-case",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members  = [
   "contracts/entry-point",
+  "contracts/adapters/hyperlane",
   "contracts/adapters/ibc/*",
   "contracts/adapters/swap/*",
   "contracts/placeholder",
@@ -20,39 +21,40 @@ documentation = "https://github.com/skip-mev/skip-go-cosmwasm-contracts#readme"
 keywords      = ["cosmwasm"]
 
 [workspace.dependencies]
-astroport        = "2.9"
-astrovault       = "0.1.8"
-dexter           = "1.4.0"
-dexter-vault     = "1.1.0"
+astroport            = "2.9"
+astrovault           = "0.1.8"
+dexter               = "1.4.0"
+dexter-vault         = "1.1.0"
 dexter-stable-pool   = "1.1.1"
 dexter-weighted-pool = "1.1.1"
-dexter-lp-token  = "1.0.0"
-dexter-router    = "1.1.0"
-cosmwasm-schema  = "1.5.4"
-cosmwasm-std     = { version = "1.5.4", features = ["stargate"] }
-cosmos-sdk-proto = { version = "0.19", default-features = false }
-cw2              = "1.1"
-cw20             = "1.1"
-cw-storage-plus  = "1"
-cw-utils         = "1.0.3"
-cw-multi-test    = "0.20.0"
-ibc-proto        = { version = "0.32.1", default-features = false }
-lido-satellite   = { git = "https://github.com/hadronlabs-org/lido-satellite", branch = "main", features = ["library"] }
-drop-factory     = { git = "https://github.com/hadronlabs-org/drop-contracts.git", branch = "feat/audit-fixes", features = ["library"] }
-drop-staking-base = { git = "https://github.com/hadronlabs-org/drop-contracts.git", branch = "feat/audit-fixes", features = ["library"] }
-mockall          = "0.12.1"
-neutron-proto    = { version = "0.1.1", default-features = false, features = ["cosmwasm"] }
-neutron-sdk      = "0.10.0"
-osmosis-std      = "0.15.3"
-prost            = "0.11"
-pryzm-std        = "0.1.7"
-serde            = { version = "1.0.194", default-features = false, features = ["derive"] }
-serde-cw-value   = "0.7.0"
-serde-json-wasm  = "1.0.1"
-skip             = { version = "0.3.0", path = "./packages/skip" }
-test-case        = "3.3.1"
-thiserror        = "1"
-white-whale-std  = "1.1.1"
+dexter-lp-token      = "1.0.0"
+dexter-router        = "1.1.0"
+cosmwasm-schema      = "1.5.4"
+cosmwasm-std         = { version = "1.5.4", features = ["stargate"] }
+cosmos-sdk-proto     = { version = "0.19", default-features = false }
+cw2                  = "1.1"
+cw20                 = "1.1"
+cw-storage-plus      = "1"
+cw-utils             = "1.0.3"
+cw-multi-test        = "0.20.0"
+hpl-interface        = { git = "https://github.com/many-things/cw-hyperlane.git", branch = "main", features = ["library"] }
+ibc-proto            = { version = "0.32.1", default-features = false }
+lido-satellite       = { git = "https://github.com/hadronlabs-org/lido-satellite", branch = "main", features = ["library"] }
+drop-factory         = { git = "https://github.com/hadronlabs-org/drop-contracts.git", branch = "feat/audit-fixes", features = ["library"] }
+drop-staking-base    = { git = "https://github.com/hadronlabs-org/drop-contracts.git", branch = "feat/audit-fixes", features = ["library"] }
+mockall              = "0.12.1"
+neutron-proto        = { version = "0.1.1", default-features = false, features = ["cosmwasm"] }
+neutron-sdk          = "0.10.0"
+osmosis-std          = "0.15.3"
+prost                = "0.11"
+pryzm-std            = "0.1.7"
+serde                = { version = "1.0.194", default-features = false, features = ["derive"] }
+serde-cw-value       = "0.7.0"
+serde-json-wasm      = "1.0.1"
+skip                 = { version = "0.3.0", path = "./packages/skip" }
+test-case            = "3.3.1"
+thiserror            = "1"
+white-whale-std      = "1.1.1"
 
 [profile.release]
 codegen-units    = 1

--- a/contracts/adapters/hyperlane/Cargo.toml
+++ b/contracts/adapters/hyperlane/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name          = "skip-go-hyperlane-adapter"
+version       = { workspace = true }
+rust-version  = { workspace = true }
+authors       = { workspace = true }
+edition       = { workspace = true }
+license       = { workspace = true }
+homepage      = { workspace = true }
+repository    = { workspace = true }
+documentation = { workspace = true }
+keywords      = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cosmwasm-schema  = { workspace = true }
+cosmwasm-std     = { workspace = true }
+cw2              = { workspace = true }
+cw-storage-plus  = { workspace = true }
+cw-utils         = { workspace = true }
+hpl-interface    = { workspace = true }
+ibc-proto        = { workspace = true }
+prost            = { workspace = true }
+serde-json-wasm  = { workspace = true }
+serde-cw-value   = { workspace = true }
+skip             = { workspace = true }
+thiserror        = { workspace = true }
+
+[dev-dependencies]
+test-case        = { workspace = true }

--- a/contracts/adapters/hyperlane/Cargo.toml
+++ b/contracts/adapters/hyperlane/Cargo.toml
@@ -26,7 +26,6 @@ cw2              = { workspace = true }
 cw-storage-plus  = { workspace = true }
 cw-utils         = { workspace = true }
 hpl-interface    = { workspace = true }
-ibc-proto        = { workspace = true }
 prost            = { workspace = true }
 serde-json-wasm  = { workspace = true }
 serde-cw-value   = { workspace = true }

--- a/contracts/adapters/hyperlane/src/bin/hyperlane-schema.rs
+++ b/contracts/adapters/hyperlane/src/bin/hyperlane-schema.rs
@@ -1,0 +1,10 @@
+use cosmwasm_schema::write_api;
+use skip::ibc::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg
+    }
+}

--- a/contracts/adapters/hyperlane/src/contract.rs
+++ b/contracts/adapters/hyperlane/src/contract.rs
@@ -1,0 +1,137 @@
+use crate::{
+    error::{ContractError, ContractResult},
+    state::ENTRY_POINT_CONTRACT_ADDRESS,
+};
+use cosmwasm_std::{entry_point, to_json_binary, DepsMut, Env, HexBinary, MessageInfo, Response};
+use cw2::set_contract_version;
+use cw_utils::one_coin;
+use hpl_interface::warp::native::ExecuteMsg::TransferRemote;
+use skip::{
+    asset::Asset,
+    hyperlane::{ExecuteMsg, InstantiateMsg, MigrateMsg},
+};
+
+///////////////
+/// MIGRATE ///
+///////////////
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> ContractResult<Response> {
+    // Set contract version
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    // Validate entry point contract address
+    let checked_entry_point_contract_address =
+        deps.api.addr_validate(&msg.entry_point_contract_address)?;
+
+    // Store the entry point contract address
+    ENTRY_POINT_CONTRACT_ADDRESS.save(deps.storage, &checked_entry_point_contract_address)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "migrate")
+        .add_attribute(
+            "entry_point_contract_address",
+            checked_entry_point_contract_address.to_string(),
+        ))
+}
+
+///////////////////
+/// INSTANTIATE ///
+///////////////////
+
+// Contract name and version used for migration.
+const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> ContractResult<Response> {
+    // Set contract version
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    // Validate entry point contract address
+    let checked_entry_point_contract_address =
+        deps.api.addr_validate(&msg.entry_point_contract_address)?;
+
+    // Store the entry point contract address
+    ENTRY_POINT_CONTRACT_ADDRESS.save(deps.storage, &checked_entry_point_contract_address)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "instantiate")
+        .add_attribute(
+            "entry_point_contract_address",
+            checked_entry_point_contract_address.to_string(),
+        ))
+}
+
+///////////////
+/// EXECUTE ///
+///////////////
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> ContractResult<Response> {
+    match msg {
+        ExecuteMsg::HplTransfer {
+            dest_domain,
+            recipient,
+            hook,
+            metadata,
+            warp_address,
+        } => execute_hpl_transfer(
+            deps,
+            info,
+            dest_domain,
+            recipient,
+            hook,
+            metadata,
+            warp_address,
+        ),
+    }
+}
+
+// Converts the given info and coin into a Hyperlane remote transfer
+fn execute_hpl_transfer(
+    deps: DepsMut,
+    info: MessageInfo,
+    dest_domain: u32,
+    recipient: HexBinary,
+    hook: Option<String>,
+    metadata: Option<HexBinary>,
+    warp_address: String,
+) -> ContractResult<Response> {
+    // Get entry point contract address from storage
+    let entry_point_contract_address = ENTRY_POINT_CONTRACT_ADDRESS.load(deps.storage)?;
+
+    // Enforce the caller is the entry point contract
+    if info.sender != entry_point_contract_address {
+        return Err(ContractError::Unauthorized);
+    }
+
+    // Get the asset from the info
+    let asset: Asset = one_coin(&info)?.into();
+
+    // Create the Hyperlane remote transfer message
+    let msg = to_json_binary(&TransferRemote {
+        dest_domain,
+        recipient,
+        amount: asset.amount(),
+        hook,
+        metadata,
+    })?;
+
+    // Convert the hyperlane transfer message into a wasm message
+    let hpl_msg = asset.into_wasm_msg(warp_address, msg)?;
+
+    Ok(Response::new()
+        .add_message(hpl_msg)
+        .add_attribute("action", "execute_hyperlane_transfer"))
+}

--- a/contracts/adapters/hyperlane/src/error.rs
+++ b/contracts/adapters/hyperlane/src/error.rs
@@ -1,0 +1,20 @@
+use cosmwasm_std::StdError;
+use skip::error::SkipError;
+use thiserror::Error;
+
+pub type ContractResult<T> = core::result::Result<T, ContractError>;
+
+#[derive(Error, Debug)]
+pub enum ContractError {
+    #[error(transparent)]
+    Std(#[from] StdError),
+
+    #[error(transparent)]
+    Skip(#[from] SkipError),
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error(transparent)]
+    Payment(#[from] cw_utils::PaymentError),
+}

--- a/contracts/adapters/hyperlane/src/lib.rs
+++ b/contracts/adapters/hyperlane/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod contract;
+pub mod error;
+pub mod state;

--- a/contracts/adapters/hyperlane/src/state.rs
+++ b/contracts/adapters/hyperlane/src/state.rs
@@ -1,0 +1,4 @@
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
+
+pub const ENTRY_POINT_CONTRACT_ADDRESS: Item<Addr> = Item::new("entry_point_contract_address");

--- a/contracts/entry-point/src/contract.rs
+++ b/contracts/entry-point/src/contract.rs
@@ -1,8 +1,8 @@
 use crate::{
     error::{ContractError, ContractResult},
     execute::{
-        execute_post_swap_action, execute_swap_and_action, execute_swap_and_action_with_recover,
-        execute_user_swap, receive_cw20,
+        execute_action, execute_post_swap_action, execute_swap_and_action,
+        execute_swap_and_action_with_recover, execute_user_swap, receive_cw20,
     },
     query::{query_ibc_transfer_adapter_contract, query_swap_venue_adapter_contract},
     reply::{reply_swap_and_action_with_recover, RECOVER_REPLY_ID},
@@ -173,6 +173,22 @@ pub fn execute(
             timeout_timestamp,
             post_swap_action,
             exact_out,
+        ),
+        ExecuteMsg::Action {
+            sent_asset,
+            timeout_timestamp,
+            action,
+            exact_out,
+            min_asset,
+        } => execute_action(
+            deps,
+            env,
+            info,
+            sent_asset,
+            timeout_timestamp,
+            action,
+            exact_out,
+            min_asset,
         ),
     }
 }

--- a/contracts/entry-point/src/contract.rs
+++ b/contracts/entry-point/src/contract.rs
@@ -1,8 +1,9 @@
 use crate::{
     error::{ContractError, ContractResult},
     execute::{
-        execute_action, execute_post_swap_action, execute_swap_and_action,
-        execute_swap_and_action_with_recover, execute_user_swap, receive_cw20,
+        execute_action, execute_action_with_recover, execute_post_swap_action,
+        execute_swap_and_action, execute_swap_and_action_with_recover, execute_user_swap,
+        receive_cw20,
     },
     query::{query_ibc_transfer_adapter_contract, query_swap_venue_adapter_contract},
     reply::{reply_swap_and_action_with_recover, RECOVER_REPLY_ID},
@@ -189,6 +190,24 @@ pub fn execute(
             action,
             exact_out,
             min_asset,
+        ),
+        ExecuteMsg::ActionWithRecover {
+            sent_asset,
+            timeout_timestamp,
+            action,
+            exact_out,
+            min_asset,
+            recovery_addr,
+        } => execute_action_with_recover(
+            deps,
+            env,
+            info,
+            sent_asset,
+            timeout_timestamp,
+            action,
+            exact_out,
+            min_asset,
+            recovery_addr,
         ),
     }
 }

--- a/contracts/entry-point/src/error.rs
+++ b/contracts/entry-point/src/error.rs
@@ -71,4 +71,17 @@ pub enum ContractError {
 
     #[error("Reply id: {0} not valid")]
     ReplyIdError(u64),
+
+    //////////////////
+    ///   ACTION   ///
+    //////////////////
+
+    #[error("No Minimum Asset Provided with Exact Out Action")]
+    NoMinAssetProvided,
+
+    #[error("Sent Asset and Min Asset Denoms Do Not Match with Exact Out Action")]
+    ActionDenomMismatch,
+
+    #[error("Remaining Asset Less Than Min Asset with Exact Out Action")]
+    RemainingAssetLessThanMinAsset,
 }

--- a/contracts/entry-point/src/error.rs
+++ b/contracts/entry-point/src/error.rs
@@ -69,6 +69,9 @@ pub enum ContractError {
     )]
     NonNativeIbcTransfer,
 
+    #[error("Hyperlane Transfer Adapter Only Supports Native Coins")]
+    NonNativeHplTransfer,
+
     #[error("Reply id: {0} not valid")]
     ReplyIdError(u64),
 

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -78,6 +78,38 @@ pub fn receive_cw20(
             post_swap_action,
             affiliates,
         ),
+        Cw20HookMsg::Action {
+            timeout_timestamp,
+            action,
+            exact_out,
+            min_asset,
+        } => execute_action(
+            deps,
+            env,
+            info,
+            Some(sent_asset),
+            timeout_timestamp,
+            action,
+            exact_out,
+            min_asset,
+        ),
+        Cw20HookMsg::ActionWithRecover {
+            timeout_timestamp,
+            action,
+            exact_out,
+            min_asset,
+            recovery_addr,
+        } => execute_action_with_recover(
+            deps,
+            env,
+            info,
+            Some(sent_asset),
+            timeout_timestamp,
+            action,
+            exact_out,
+            min_asset,
+            recovery_addr,
+        ),
     }
 }
 

--- a/contracts/entry-point/src/state.rs
+++ b/contracts/entry-point/src/state.rs
@@ -5,6 +5,8 @@ use cw_storage_plus::{Item, Map};
 pub const BLOCKED_CONTRACT_ADDRESSES: Map<&Addr, ()> = Map::new("blocked_contract_addresses");
 pub const SWAP_VENUE_MAP: Map<&str, Addr> = Map::new("swap_venue_map");
 pub const IBC_TRANSFER_CONTRACT_ADDRESS: Item<Addr> = Item::new("ibc_transfer_contract_address");
+pub const HYPERLANE_TRANSFER_CONTRACT_ADDRESS: Item<Addr> =
+    Item::new("hyperlane_transfer_contract_address");
 
 // Temporary state to save variables to be used in
 // reply handling in case of recovering from an error

--- a/contracts/entry-point/tests/test_execute_action.rs
+++ b/contracts/entry-point/tests/test_execute_action.rs
@@ -1,0 +1,498 @@
+use cosmwasm_std::{
+    testing::{mock_dependencies_with_balances, mock_env, mock_info},
+    to_json_binary, Addr, BankMsg, Coin, ContractResult, QuerierResult,
+    ReplyOn::Never,
+    SubMsg, SystemResult, Timestamp, Uint128, WasmMsg, WasmQuery,
+};
+use cw20::{BalanceResponse, Cw20Coin, Cw20ExecuteMsg};
+use skip::{
+    asset::Asset,
+    entry_point::{Action, ExecuteMsg},
+    ibc::{ExecuteMsg as IbcTransferExecuteMsg, IbcFee, IbcInfo},
+};
+use skip_go_entry_point::{
+    error::ContractError,
+    state::{BLOCKED_CONTRACT_ADDRESSES, IBC_TRANSFER_CONTRACT_ADDRESS},
+};
+use test_case::test_case;
+
+/*
+Test Cases:
+
+Expect Response
+    // General
+    - Native Asset Transfer
+    - Cw20 Asset Transfer
+    - Ibc Transfer
+    - Native Asset Contract Call
+    - Cw20 Asset Contract Call
+
+    // Exact Out
+    - Ibc Transfer With Exact Out Set To True
+    - Ibc Transfer w/ IBC Fees of same denom as min coin With Exact Out Set To True
+
+Expect Error
+    - Remaining Asset Less Than Min Asset - Native
+    - Remaining Asset Less Than Min Asset - CW20
+    - Contract Call Address Blocked
+    - Ibc Transfer w/ IBC Fees of different denom than min coin no fee swap
+ */
+
+// Define test parameters
+struct Params {
+    info_funds: Vec<Coin>,
+    sent_asset: Option<Asset>,
+    action: Action,
+    exact_out: bool,
+    min_asset: Option<Asset>,
+    expected_messages: Vec<SubMsg>,
+    expected_error: Option<ContractError>,
+}
+
+// Test execute_action
+#[test_case(
+    Params {
+        info_funds: vec![Coin::new(1_000_000, "os")],
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "os"))),
+        min_asset: None,
+        action: Action::Transfer {
+            to_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5".to_string(),
+        },
+        exact_out: false,
+        expected_messages: vec![SubMsg {
+            id: 0,
+            msg: BankMsg::Send {
+                to_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5".to_string(),
+                amount: vec![Coin::new(1_000_000, "os")],
+            }
+            .into(),
+            gas_limit: None,
+            reply_on: Never,
+        }],
+        expected_error: None,
+    };
+    "Native Asset Transfer")]
+#[test_case(
+    Params {
+        info_funds: vec![],
+        sent_asset: Some(Asset::Cw20(Cw20Coin{
+            address: "neutron123".to_string(),
+            amount: Uint128::new(1_000_000),
+        })),
+        min_asset: None,
+        action: Action::Transfer {
+            to_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5".to_string(),
+        },
+        exact_out: false,
+        expected_messages: vec![SubMsg {
+            id: 0,
+            msg: WasmMsg::Execute {
+                contract_addr: "neutron123".to_string(),
+                msg: to_json_binary(&Cw20ExecuteMsg::Transfer {
+                    recipient: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5".to_string(),
+                    amount: Uint128::new(1_000_000),
+                }).unwrap(),
+                funds: vec![],
+            }
+            .into(),
+            gas_limit: None,
+            reply_on: Never,
+        }],
+        expected_error: None,
+    };
+    "Cw20 Asset Transfer")]
+#[test_case(
+    Params {
+        info_funds: vec![Coin::new(1_000_000, "os")],
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "os"))),
+        min_asset: None,
+        action: Action::IbcTransfer {
+            ibc_info: IbcInfo {
+                source_channel: "channel-0".to_string(),
+                receiver: "receiver".to_string(),
+                memo: "".to_string(),
+                fee: None,
+                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                    .to_string(),
+            },
+            fee_swap: None,
+        },
+        exact_out: false,
+        expected_messages: vec![SubMsg {
+            id: 0,
+            msg: WasmMsg::Execute {
+                contract_addr: "ibc_transfer_adapter".to_string(),
+                msg: to_json_binary(&IbcTransferExecuteMsg::IbcTransfer {
+                    info: IbcInfo {
+                        source_channel: "channel-0".to_string(),
+                        receiver: "receiver".to_string(),
+                        memo: "".to_string(),
+                        fee: None,
+                        recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                            .to_string(),
+                    },
+                    coin: Coin::new(1_000_000, "os"),
+                    timeout_timestamp: 101,
+                })
+                .unwrap(),
+                funds: vec![Coin::new(1_000_000, "os")],
+            }
+            .into(),
+            gas_limit: None,
+            reply_on: Never,
+        }],
+        expected_error: None,
+    };
+    "Ibc Transfer")]
+#[test_case(
+    Params {
+        info_funds: vec![Coin::new(1_000_000, "os")],
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "os"))),
+        min_asset: None,
+        action: Action::ContractCall {
+            contract_address: "contract_call".to_string(),
+            msg: to_json_binary(&"contract_call_msg").unwrap(),
+        },
+        exact_out: false,
+        expected_messages: vec![SubMsg {
+            id: 0,
+            msg: WasmMsg::Execute {
+                contract_addr: "contract_call".to_string(),
+                msg: to_json_binary(&"contract_call_msg").unwrap(),
+                funds: vec![Coin::new(1_000_000, "os")],
+            }
+            .into(),
+            gas_limit: None,
+            reply_on: Never,
+        }],
+        expected_error: None,
+    };
+    "Native Asset Contract Call")]
+#[test_case(
+    Params {
+        info_funds: vec![],
+        sent_asset: Some(Asset::Cw20(Cw20Coin{
+            address: "neutron123".to_string(),
+            amount: Uint128::new(1_000_000),
+        })),
+        min_asset: None,
+        action: Action::ContractCall {
+            contract_address: "contract_call".to_string(),
+            msg: to_json_binary(&"contract_call_msg").unwrap(),
+        },
+        exact_out: false,
+        expected_messages: vec![SubMsg {
+            id: 0,
+            msg: WasmMsg::Execute {
+                contract_addr: "neutron123".to_string(),
+                msg: to_json_binary(&Cw20ExecuteMsg::Send {
+                    contract: "contract_call".to_string(),
+                    amount: Uint128::new(1_000_000),
+                    msg: to_json_binary(&"contract_call_msg").unwrap(),
+                }).unwrap(),
+                funds: vec![],
+            }
+            .into(),
+            gas_limit: None,
+            reply_on: Never,
+        }],
+        expected_error: None,
+    };
+    "Cw20 Asset Contract Call")]
+#[test_case(
+    Params {
+        info_funds: vec![Coin::new(1_000_000, "os")],
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "os"))),
+        min_asset: Some(Asset::Native(Coin::new(900_000, "os"))),
+        action: Action::IbcTransfer {
+            ibc_info: IbcInfo {
+                source_channel: "channel-0".to_string(),
+                receiver: "receiver".to_string(),
+                memo: "".to_string(),
+                fee: None,
+                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                    .to_string(),
+            },
+            fee_swap: None,
+        },
+        exact_out: true,
+        expected_messages: vec![SubMsg {
+            id: 0,
+            msg: WasmMsg::Execute {
+                contract_addr: "ibc_transfer_adapter".to_string(),
+                msg: to_json_binary(&IbcTransferExecuteMsg::IbcTransfer {
+                    info: IbcInfo {
+                        source_channel: "channel-0".to_string(),
+                        receiver: "receiver".to_string(),
+                        memo: "".to_string(),
+                        fee: None,
+                        recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                            .to_string(),
+                    },
+                    coin: Coin::new(900_000, "os"),
+                    timeout_timestamp: 101,
+                })
+                .unwrap(),
+                funds: vec![Coin::new(900_000, "os")],
+            }
+            .into(),
+            gas_limit: None,
+            reply_on: Never,
+        }],
+        expected_error: None,
+    };
+    "Ibc Transfer With Exact Out Set To True")]
+#[test_case(
+    Params {
+        info_funds: vec![Coin::new(1_200_000, "os")],
+        sent_asset: Some(Asset::Native(Coin::new(1_200_000, "os"))),
+        min_asset: Some(Asset::Native(Coin::new(900_000, "os"))),
+        action: Action::IbcTransfer {
+            ibc_info: IbcInfo {
+                source_channel: "channel-0".to_string(),
+                receiver: "receiver".to_string(),
+                memo: "".to_string(),
+                fee: Some(IbcFee {
+                    recv_fee: vec![],
+                    ack_fee: vec![Coin::new(100_000, "os")],
+                    timeout_fee: vec![Coin::new(100_000, "os")],
+                }),
+                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                    .to_string(),
+            },
+            fee_swap: None,
+        },
+        exact_out: true,
+        expected_messages: vec![
+        SubMsg {
+            id: 0,
+            msg: BankMsg::Send {
+                to_address: "ibc_transfer_adapter".to_string(),
+                amount: vec![Coin::new(200_000, "os")],
+            }
+            .into(),
+            gas_limit: None,
+            reply_on: Never,
+        },
+        SubMsg {
+            id: 0,
+            msg: WasmMsg::Execute {
+                contract_addr: "ibc_transfer_adapter".to_string(),
+                msg: to_json_binary(&IbcTransferExecuteMsg::IbcTransfer {
+                    info: IbcInfo {
+                        source_channel: "channel-0".to_string(),
+                        receiver: "receiver".to_string(),
+                        memo: "".to_string(),
+                        fee: Some(IbcFee {
+                            recv_fee: vec![],
+                            ack_fee: vec![Coin::new(100_000, "os")],
+                            timeout_fee: vec![Coin::new(100_000, "os")],
+                        }),
+                        recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                            .to_string(),
+                    },
+                    coin: Coin::new(900_000, "os"),
+                    timeout_timestamp: 101,
+                })
+                .unwrap(),
+                funds: vec![Coin::new(900_000, "os")],
+            }
+            .into(),
+            gas_limit: None,
+            reply_on: Never,
+        }],
+        expected_error: None,
+    };
+    "Ibc Transfer w/ IBC Fees of same denom as min coin With Exact Out Set To True")]
+#[test_case(
+    Params {
+        info_funds: vec![Coin::new(1_000_000, "os")],
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "os"))),
+        min_asset: Some(Asset::Native(Coin::new(900_000, "os"))),
+        action: Action::IbcTransfer {
+            ibc_info: IbcInfo {
+                source_channel: "channel-0".to_string(),
+                receiver: "receiver".to_string(),
+                memo: "".to_string(),
+                fee: Some(IbcFee {
+                    recv_fee: vec![],
+                    ack_fee: vec![Coin::new(100_000, "un")],
+                    timeout_fee: vec![Coin::new(100_000, "un")],
+                }),
+                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                    .to_string(),
+            },
+            fee_swap: None,
+        },
+        exact_out: true,
+        expected_messages: vec![SubMsg {
+            id: 0,
+            msg: WasmMsg::Execute {
+                contract_addr: "ibc_transfer_adapter".to_string(),
+                msg: to_json_binary(&IbcTransferExecuteMsg::IbcTransfer {
+                    info: IbcInfo {
+                        source_channel: "channel-0".to_string(),
+                        receiver: "receiver".to_string(),
+                        memo: "".to_string(),
+                        fee: Some(IbcFee {
+                            recv_fee: vec![],
+                            ack_fee: vec![Coin::new(100_000, "un")],
+                            timeout_fee: vec![Coin::new(100_000, "un")],
+                        }),
+                        recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                            .to_string(),
+                    },
+                    coin: Coin::new(900_000, "os"),
+                    timeout_timestamp: 101,
+                })
+                .unwrap(),
+                funds: vec![Coin::new(900_000, "os")],
+            }
+            .into(),
+            gas_limit: None,
+            reply_on: Never,
+        }],
+        expected_error: Some(ContractError::IBCFeeDenomDiffersFromAssetReceived),
+    };
+    "Ibc Transfer w/ IBC Fees of different denom than min coin no fee swap - Expect Error")]
+#[test_case(
+    Params {
+        info_funds: vec![Coin::new(1_000_000, "os")],
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "os"))),
+        min_asset: Some(Asset::Native(Coin::new(1_100_000, "os"))),
+        action: Action::ContractCall {
+            contract_address: "entry_point".to_string(),
+            msg: to_json_binary(&"contract_call_msg").unwrap(),
+        },
+        exact_out: true,
+        expected_messages: vec![],
+        expected_error: Some(ContractError::RemainingAssetLessThanMinAsset),
+    };
+    "Remaining Asset Less Than Min Asset Native - Expect Error")]
+#[test_case(
+    Params {
+        info_funds: vec![],
+        sent_asset: Some(Asset::Cw20(Cw20Coin{
+            address: "neutron123".to_string(),
+            amount: Uint128::new(1_000_000),
+        })),
+        min_asset: Some(Asset::Cw20(Cw20Coin{
+            address: "neutron123".to_string(),
+            amount: Uint128::new(2_100_000),
+        })),
+        action: Action::ContractCall {
+            contract_address: "entry_point".to_string(),
+            msg: to_json_binary(&"contract_call_msg").unwrap(),
+        },
+        exact_out: true,
+        expected_messages: vec![],
+        expected_error: Some(ContractError::RemainingAssetLessThanMinAsset),
+    };
+    "Remaining Asset Less Than Min Asset CW20 - Expect Error")]
+#[test_case(
+    Params {
+        info_funds: vec![Coin::new(1_000_000, "os")],
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "os"))),
+        min_asset: None,
+        action: Action::ContractCall {
+            contract_address: "entry_point".to_string(),
+            msg: to_json_binary(&"contract_call_msg").unwrap(),
+        },
+        exact_out: false,
+        expected_messages: vec![],
+        expected_error: Some(ContractError::ContractCallAddressBlocked),
+    };
+    "Contract Call Address Blocked - Expect Error")]
+fn test_execute_post_swap_action(params: Params) {
+    // Create mock dependencies
+    let mut deps = mock_dependencies_with_balances(&[(
+        "entry_point",
+        &[Coin::new(1_000_000, "os"), Coin::new(1_000_000, "un")],
+    )]);
+
+    // Create mock wasm handler to handle the swap adapter contract query
+    let wasm_handler = |query: &WasmQuery| -> QuerierResult {
+        match query {
+            WasmQuery::Smart { .. } => SystemResult::Ok(ContractResult::Ok(
+                to_json_binary(&BalanceResponse {
+                    balance: Uint128::from(1_000_000u128),
+                })
+                .unwrap(),
+            )),
+            _ => panic!("Unsupported query: {:?}", query),
+        }
+    };
+
+    // Update querier with mock wasm handler
+    deps.querier.update_wasm(wasm_handler);
+
+    // Create mock env with parameters that make testing easier
+    let mut env = mock_env();
+    env.contract.address = Addr::unchecked("entry_point");
+    env.block.time = Timestamp::from_nanos(100);
+
+    // Convert info funds vector into a slice of Coin objects
+    let info_funds: &[Coin] = &params.info_funds;
+
+    // Create mock info with entry point contract address
+    let info = mock_info("actioner", info_funds);
+
+    // Store the ibc transfer adapter contract address
+    let ibc_transfer_adapter = Addr::unchecked("ibc_transfer_adapter");
+    IBC_TRANSFER_CONTRACT_ADDRESS
+        .save(deps.as_mut().storage, &ibc_transfer_adapter)
+        .unwrap();
+
+    // Store the entry point contract address in the blocked contract addresses map
+    BLOCKED_CONTRACT_ADDRESSES
+        .save(deps.as_mut().storage, &Addr::unchecked("entry_point"), &())
+        .unwrap();
+
+    // Call execute_post_swap_action with the given test parameters
+    let res = skip_go_entry_point::contract::execute(
+        deps.as_mut(),
+        env,
+        info,
+        ExecuteMsg::Action {
+            sent_asset: params.sent_asset,
+            timeout_timestamp: 101,
+            action: params.action,
+            exact_out: params.exact_out,
+            min_asset: params.min_asset,
+        },
+    );
+
+    match res {
+        Ok(res) => {
+            // Assert the test did not expect an error
+            assert!(
+                params.expected_error.is_none(),
+                "expected test to error with {:?}, but it succeeded",
+                params.expected_error
+            );
+
+            // Assert the number of messages in the response is correct
+            assert_eq!(
+                res.messages.len(),
+                params.expected_messages.len(),
+                "expected {:?} messages, but got {:?}",
+                params.expected_messages.len(),
+                res.messages.len()
+            );
+
+            // Assert the messages in the response are correct
+            assert_eq!(res.messages, params.expected_messages,);
+        }
+        Err(err) => {
+            // Assert the test expected an error
+            assert!(
+                params.expected_error.is_some(),
+                "expected test to succeed, but it errored with {:?}",
+                err
+            );
+
+            // Assert the error is correct
+            assert_eq!(err, params.expected_error.unwrap());
+        }
+    }
+}

--- a/contracts/entry-point/tests/test_instantiate.rs
+++ b/contracts/entry-point/tests/test_instantiate.rs
@@ -78,6 +78,7 @@ fn test_instantiate(params: Params) {
         InstantiateMsg {
             swap_venues: params.swap_venues.clone(),
             ibc_transfer_contract_address: params.ibc_transfer_contract_address,
+            hyperlane_transfer_contract_address: None,
         },
     );
 

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -101,6 +101,19 @@ pub enum Cw20HookMsg {
         post_swap_action: Action,
         affiliates: Vec<Affiliate>,
     },
+    Action {
+        timeout_timestamp: u64,
+        action: Action,
+        exact_out: bool,
+        min_asset: Option<Asset>,
+    },
+    ActionWithRecover {
+        timeout_timestamp: u64,
+        action: Action,
+        exact_out: bool,
+        min_asset: Option<Asset>,
+        recovery_addr: Addr,
+    },
 }
 
 /////////////

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -66,6 +66,13 @@ pub enum ExecuteMsg {
         post_swap_action: Action,
         exact_out: bool,
     },
+    Action {
+        sent_asset: Option<Asset>,
+        timeout_timestamp: u64,
+        action: Action,
+        exact_out: bool,
+        min_asset: Option<Asset>,
+    },
 }
 
 /// This structure describes a CW20 hook message.

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -73,6 +73,14 @@ pub enum ExecuteMsg {
         exact_out: bool,
         min_asset: Option<Asset>,
     },
+    ActionWithRecover {
+        sent_asset: Option<Asset>,
+        timeout_timestamp: u64,
+        action: Action,
+        exact_out: bool,
+        min_asset: Option<Asset>,
+        recovery_addr: Addr,
+    },
 }
 
 /// This structure describes a CW20 hook message.

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Binary, Uint128};
+use cosmwasm_std::{Addr, Binary, HexBinary, Uint128};
 use cw20::Cw20ReceiveMsg;
 
 ///////////////
@@ -25,6 +25,7 @@ pub struct MigrateMsg {}
 pub struct InstantiateMsg {
     pub swap_venues: Vec<SwapVenue>,
     pub ibc_transfer_contract_address: String,
+    pub hyperlane_transfer_contract_address: Option<String>,
 }
 
 ///////////////
@@ -152,6 +153,13 @@ pub enum Action {
     ContractCall {
         contract_address: String,
         msg: Binary,
+    },
+    HplTransfer {
+        dest_domain: u32,
+        recipient: HexBinary,
+        hook: Option<String>,
+        metadata: Option<HexBinary>,
+        warp_address: String,
     },
 }
 

--- a/packages/skip/src/hyperlane.rs
+++ b/packages/skip/src/hyperlane.rs
@@ -1,0 +1,37 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::HexBinary;
+
+///////////////
+/// MIGRATE ///
+///////////////
+
+// The MigrateMsg struct defines the migration parameters used.
+#[cw_serde]
+pub struct MigrateMsg {
+    pub entry_point_contract_address: String,
+}
+///////////////////
+/// INSTANTIATE ///
+///////////////////
+
+// The InstantiateMsg struct defines the initialization parameters for the IBC Transfer Adapter contracts.
+#[cw_serde]
+pub struct InstantiateMsg {
+    pub entry_point_contract_address: String,
+}
+
+///////////////
+/// EXECUTE ///
+///////////////
+
+// The ExecuteMsg enum defines the execution message that the IBC Transfer Adapter contracts can handle.
+#[cw_serde]
+pub enum ExecuteMsg {
+    HplTransfer {
+        dest_domain: u32,
+        recipient: HexBinary,
+        hook: Option<String>,
+        metadata: Option<HexBinary>,
+        warp_address: String,
+    },
+}

--- a/packages/skip/src/lib.rs
+++ b/packages/skip/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod asset;
 pub mod entry_point;
 pub mod error;
+pub mod hyperlane;
 pub mod ibc;
 pub mod proto_coin;
 pub mod sudo;

--- a/schema/raw/execute.json
+++ b/schema/raw/execute.json
@@ -381,6 +381,53 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "hpl_transfer"
+          ],
+          "properties": {
+            "hpl_transfer": {
+              "type": "object",
+              "required": [
+                "dest_domain",
+                "recipient",
+                "warp_address"
+              ],
+              "properties": {
+                "dest_domain": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "hook": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "metadata": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/HexBinary"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "recipient": {
+                  "$ref": "#/definitions/HexBinary"
+                },
+                "warp_address": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -487,6 +534,10 @@
         }
       },
       "additionalProperties": false
+    },
+    "HexBinary": {
+      "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
     },
     "IbcFee": {
       "description": "COMMON TYPES ///",

--- a/schema/raw/execute.json
+++ b/schema/raw/execute.json
@@ -193,6 +193,112 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "action"
+      ],
+      "properties": {
+        "action": {
+          "type": "object",
+          "required": [
+            "action",
+            "exact_out",
+            "timeout_timestamp"
+          ],
+          "properties": {
+            "action": {
+              "$ref": "#/definitions/Action"
+            },
+            "exact_out": {
+              "type": "boolean"
+            },
+            "min_asset": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Asset"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "sent_asset": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Asset"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "timeout_timestamp": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "action_with_recover"
+      ],
+      "properties": {
+        "action_with_recover": {
+          "type": "object",
+          "required": [
+            "action",
+            "exact_out",
+            "recovery_addr",
+            "timeout_timestamp"
+          ],
+          "properties": {
+            "action": {
+              "$ref": "#/definitions/Action"
+            },
+            "exact_out": {
+              "type": "boolean"
+            },
+            "min_asset": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Asset"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_addr": {
+              "$ref": "#/definitions/Addr"
+            },
+            "sent_asset": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Asset"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "timeout_timestamp": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/schema/raw/instantiate.json
+++ b/schema/raw/instantiate.json
@@ -8,6 +8,12 @@
     "swap_venues"
   ],
   "properties": {
+    "hyperlane_transfer_contract_address": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "ibc_transfer_contract_address": {
       "type": "string"
     },

--- a/schema/skip-go-entry-point.json
+++ b/schema/skip-go-entry-point.json
@@ -12,6 +12,12 @@
       "swap_venues"
     ],
     "properties": {
+      "hyperlane_transfer_contract_address": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "ibc_transfer_contract_address": {
         "type": "string"
       },
@@ -426,6 +432,53 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "hpl_transfer"
+            ],
+            "properties": {
+              "hpl_transfer": {
+                "type": "object",
+                "required": [
+                  "dest_domain",
+                  "recipient",
+                  "warp_address"
+                ],
+                "properties": {
+                  "dest_domain": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  },
+                  "hook": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "metadata": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/HexBinary"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "recipient": {
+                    "$ref": "#/definitions/HexBinary"
+                  },
+                  "warp_address": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -532,6 +585,10 @@
           }
         },
         "additionalProperties": false
+      },
+      "HexBinary": {
+        "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
       },
       "IbcFee": {
         "description": "COMMON TYPES ///",

--- a/schema/skip-go-entry-point.json
+++ b/schema/skip-go-entry-point.json
@@ -238,6 +238,112 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "action"
+        ],
+        "properties": {
+          "action": {
+            "type": "object",
+            "required": [
+              "action",
+              "exact_out",
+              "timeout_timestamp"
+            ],
+            "properties": {
+              "action": {
+                "$ref": "#/definitions/Action"
+              },
+              "exact_out": {
+                "type": "boolean"
+              },
+              "min_asset": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Asset"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sent_asset": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Asset"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "timeout_timestamp": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "action_with_recover"
+        ],
+        "properties": {
+          "action_with_recover": {
+            "type": "object",
+            "required": [
+              "action",
+              "exact_out",
+              "recovery_addr",
+              "timeout_timestamp"
+            ],
+            "properties": {
+              "action": {
+                "$ref": "#/definitions/Action"
+              },
+              "exact_out": {
+                "type": "boolean"
+              },
+              "min_asset": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Asset"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "recovery_addr": {
+                "$ref": "#/definitions/Addr"
+              },
+              "sent_asset": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Asset"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "timeout_timestamp": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {


### PR DESCRIPTION
## This PR
- Implements a hyperlane remote transfer adapter contract, which takes in the coin sent to the contract along with the rest of the remote transfer metadata and calls the hyperlane warp route contract with it
- Adds the hyperlane transfer action in the entry point contract, allowing an action or post swap action to be a hyperlane transfer
- This is generally useful to allow 1-click hyperlane flows before we know the amount out of a swap