### PR TITLE
typos-Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ To deploy the Skip Swap contracts, the steps are as follows:
     MNEMONIC = "<YOUR MNEMONIC HERE>"
     ```
 
-7. Generate the entry point contract address using `instatiate2` which generates determinsitic cosmwasm contract addresses. This is necessary to allow the adapter contracts to whitelist the entry point contract before it is instantiated. To do this, you will need the daemon of the respective chain you are deploying on, and running the following command for the chain's CLI (replace osmosisd with network client being used):
+7. Generate the entry point contract address using `instatiate2` which generates deterministic cosmwasm contract addresses. This is necessary to allow the adapter contracts to whitelist the entry point contract before it is instantiated. To do this, you will need the daemon of the respective chain you are deploying on, and running the following command for the chain's CLI (replace osmosisd with network client being used):
     ```
     osmosisd query wasm build-address <CHECK SUM HASH OF CONTRACT> <ADDRESS THAT WILL INSTANTIATE> <SALT AS HEX STRING (31 is b'1')>
     ```
@@ -173,7 +173,7 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 9. Update the salt used in the config if needed (default is "1", which is 31 in the chain daemon generator)
     ``` toml
-    # SALT USED TO GENERATE A DETERMINSTIC ADDRESS
+    # SALT USED TO GENERATE A DETERMINISTIC ADDRESS
     SALT = "1"
     ```
 


### PR DESCRIPTION
# Fix: Corrected typos in README file

## Changes
1. **File**: `README.md`
   - Fixed a typo by changing "determinsitic" to "deterministic" (Line 163).
   - Fixed a typo by changing "DETERMINSTIC" to "DETERMINISTIC" (Line 176).

## Purpose
- Improved documentation accuracy by correcting typographical errors.
- Enhanced the clarity and professionalism of the README file.
