### PR TITLE
Fix typos in `README.md`, `swap.rs`, `contract.rs`, and `ibc.rs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ To deploy the Skip Swap contracts, the steps are as follows:
     MNEMONIC = "<YOUR MNEMONIC HERE>"
     ```
 
-7. Generate the entry point contract address using `instatiate2` which generates determinsitic cosmwasm contract addresses. This is necessary to allow the adapter contracts to whitelist the entry point contract before it is instantiated. To do this, you will need the daemon of the respective chain you are deploying on, and running the following command for the chain's CLI (replace osmosisd with network client being used):
+7. Generate the entry point contract address using `instatiate2` which generates deterministic cosmwasm contract addresses. This is necessary to allow the adapter contracts to whitelist the entry point contract before it is instantiated. To do this, you will need the daemon of the respective chain you are deploying on, and running the following command for the chain's CLI (replace osmosisd with network client being used):
     ```
     osmosisd query wasm build-address <CHECK SUM HASH OF CONTRACT> <ADDRESS THAT WILL INSTANTIATE> <SALT AS HEX STRING (31 is b'1')>
     ```
@@ -173,7 +173,7 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 9. Update the salt used in the config if needed (default is "1", which is 31 in the chain daemon generator)
     ``` toml
-    # SALT USED TO GENERATE A DETERMINSTIC ADDRESS
+    # SALT USED TO GENERATE A DETERMINISTIC ADDRESS
     SALT = "1"
     ```
 

--- a/contracts/adapters/swap/duality/src/contract.rs
+++ b/contracts/adapters/swap/duality/src/contract.rs
@@ -449,15 +449,15 @@ fn query_simulate_smart_swap_exact_asset_in_with_metadata(
     if routes.len() != 1 {
         return Err(ContractError::SmartSwapUnsupported);
     }
-    let responce = query_simulate_swap_exact_asset_in_with_metadata(
+    let response = query_simulate_swap_exact_asset_in_with_metadata(
         deps,
         env,
         asset_in,
         routes[0].operations.clone(),
         include_spot_price,
     )?;
-    if *responce.asset_out.denom() == ask_denom {
-        Ok(responce)
+    if *response.asset_out.denom() == ask_denom {
+        Ok(response)
     } else {
         Err(ContractError::SmartSwapUnexpectedOut)
     }

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -109,7 +109,7 @@ impl TryFrom<IbcFee> for Coins {
 
 impl IbcFee {
     // one_coin aims to mimic the behavior of cw_utls::one_coin,
-    // returing the single coin in the IbcFee struct if it exists,
+    // returning the single coin in the IbcFee struct if it exists,
     // erroring if 0 or more than 1 coins exist.
     //
     // one_coin is used because the entry_point contract only supports

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -280,7 +280,7 @@ pub struct SwapExactAssetOut {
     pub refund_address: Option<String>,
 }
 
-// Swap object that swaps the remaining asset recevied
+// Swap object that swaps the remaining asset received
 // from the contract call minus fee swap (if present)
 #[cw_serde]
 pub struct SwapExactAssetIn {
@@ -288,7 +288,7 @@ pub struct SwapExactAssetIn {
     pub operations: Vec<SwapOperation>,
 }
 
-// Swap object that swaps the remaining asset recevied
+// Swap object that swaps the remaining asset received
 // over multiple routes from the contract call minus fee swap (if present)
 #[cw_serde]
 pub struct SmartSwapExactAssetIn {


### PR DESCRIPTION
1. **`README.md`**:
   - Fixed `determinsitic` → `deterministic`
   - Fixed `DETERMINSTIC` → `DETERMINISTIC`

2. **`contract.rs`**:
   - Fixed `responce` → `response` in function calls.

3. **`ibc.rs`**:
   - Fixed `returing` → `returning` in function documentation.

4. **`swap.rs`**:
   - Fixed `recevied` → `received` in struct comments.
