### PR TITLE
Deploy IBC Callback Adapter on Babylon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,4 @@ venv
 .venv
 .env
 
-scripts/configs/*.toml
 scripts/cosmpy/*

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ venv
 .venv
 .env
 
+scripts/configs/*.toml
 scripts/cosmpy/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,17 +1607,17 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 [[package]]
 name = "drop-factory"
 version = "1.0.0"
-source = "git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes#781fd3add565ee02a2dfb568e6ab49b7c5e09b2f"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
 dependencies = [
  "cosmwasm-schema 1.5.11",
  "cosmwasm-std 1.5.11",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
- "drop-helpers",
- "drop-macros",
- "drop-puppeteer-base",
- "drop-staking-base",
+ "drop-helpers 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-macros 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-puppeteer-base 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-staking-base 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
  "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
  "semver 1.0.26",
  "thiserror 1.0.69",
@@ -1644,9 +1644,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "drop-helpers"
+version = "1.0.0"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
+dependencies = [
+ "cosmos-sdk-proto 0.20.0",
+ "cosmwasm-schema 1.5.11",
+ "cosmwasm-std 1.5.11",
+ "cw-storage-plus 1.2.0",
+ "hex",
+ "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
+ "prost 0.12.6",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "sha3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "drop-macros"
 version = "1.0.0"
 source = "git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes#781fd3add565ee02a2dfb568e6ab49b7c5e09b2f"
+dependencies = [
+ "cosmwasm-schema 1.5.11",
+ "cosmwasm-std 1.5.11",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "drop-macros"
+version = "1.0.0"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
 dependencies = [
  "cosmwasm-schema 1.5.11",
  "cosmwasm-std 1.5.11",
@@ -1667,6 +1698,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "drop-proto"
+version = "1.0.0"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
+dependencies = [
+ "cosmwasm-std 1.5.11",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "tendermint-proto 0.34.1",
+]
+
+[[package]]
 name = "drop-puppeteer-base"
 version = "1.0.0"
 source = "git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes#781fd3add565ee02a2dfb568e6ab49b7c5e09b2f"
@@ -1676,7 +1718,28 @@ dependencies = [
  "cosmwasm-std 1.5.11",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
- "drop-helpers",
+ "drop-helpers 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
+ "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "schemars",
+ "semver 1.0.26",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "drop-puppeteer-base"
+version = "1.0.0"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
+dependencies = [
+ "cosmos-sdk-proto 0.20.0",
+ "cosmwasm-schema 1.5.11",
+ "cosmwasm-std 1.5.11",
+ "cw-ownable",
+ "cw-storage-plus 1.2.0",
+ "drop-helpers 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
  "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
  "prost 0.12.6",
  "prost-types 0.12.6",
@@ -1701,10 +1764,36 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "drop-helpers",
- "drop-macros",
- "drop-proto",
- "drop-puppeteer-base",
+ "drop-helpers 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
+ "drop-macros 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
+ "drop-proto 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
+ "drop-puppeteer-base 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
+ "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
+ "optfield",
+ "prost 0.12.6",
+ "semver 1.0.26",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "drop-staking-base"
+version = "1.0.0"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
+dependencies = [
+ "astroport 3.12.2",
+ "cosmos-sdk-proto 0.20.0",
+ "cosmwasm-schema 1.5.11",
+ "cosmwasm-std 1.5.11",
+ "cw-ownable",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw721 0.18.0",
+ "cw721-base 0.18.0",
+ "drop-helpers 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-macros 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-proto 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-puppeteer-base 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
  "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
  "optfield",
  "prost 0.12.6",
@@ -3725,7 +3814,7 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "drop-factory",
- "drop-staking-base",
+ "drop-staking-base 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
  "skip",
  "test-case",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ cw-multi-test        = "0.20.0"
 hpl-interface        = { git = "https://github.com/many-things/cw-hyperlane.git", branch = "main", features = ["library"] }
 ibc-proto            = { version = "0.32.1", default-features = false }
 lido-satellite       = { git = "https://github.com/hadronlabs-org/lido-satellite", branch = "main", features = ["library"] }
-drop-factory         = { git = "https://github.com/hadronlabs-org/drop-contracts.git", branch = "feat/audit-fixes", features = ["library"] }
+drop-factory         = { git = "https://github.com/hadronlabs-org/drop-contracts.git", rev = "899ec67", features = ["library"] }
 drop-staking-base    = { git = "https://github.com/hadronlabs-org/drop-contracts.git", branch = "feat/audit-fixes", features = ["library"] }
 mockall              = "0.12.1"
 neutron-proto        = { version = "0.1.1", default-features = false, features = ["cosmwasm"] }

--- a/deployed-contracts/babylon/testnet.toml
+++ b/deployed-contracts/babylon/testnet.toml
@@ -1,7 +1,7 @@
 [info]
-chain_id = "bbn-1"
-network = "mainnet"
-deploy_date = "07/06/2025 15:20:25"
+chain_id = "bbn-test-5"
+network = "testnet"
+deploy_date = "07/06/2025 15:17:05"
 commit_hash = "0d7bfebec4416ea9e68e4521f8c81cc10280f59a"
 salt = "1"
 
@@ -26,19 +26,19 @@ salt = "1"
 "skip_go_swap_adapter_white_whale.wasm" = "c4eb808fcb79254f3a76ebeea09554590420bc4096e3d4ce612b96d4202e2d75"
 
 [code-ids]
-ibc_transfer_adapter_contract_code_id = "96"
-swap_adapter_babylon-tower_contract_code_id = "97"
-entry_point_contract_code_id = "98"
+ibc_transfer_adapter_contract_code_id = "747"
+swap_adapter_testnet-babylon-tower_contract_code_id = "748"
+entry_point_contract_code_id = "749"
 
 [contract-addresses]
-ibc_transfer_adapter_contract_address = "bbn164fjxdgf5etlpqjpeffnrksjkj6ln80cegter4c55l0uyv7uh9kq6szuu8"
-swap_adapter_babylon-tower_contract_address = "bbn1wk2jm4mcgsc5y0sqs40exwzxyylv3p3hvmkanj2qmd0zph0n0l7qt44qz8"
+ibc_transfer_adapter_contract_address = "bbn1fcfgnfuyegxqnen0ulfknpsaeg6z0ktm5u8e32h568nkcqpunuvq5tgtr0"
+swap_adapter_testnet-babylon-tower_contract_address = "bbn1zvujq5mvw6ypvf2slw5x70pwwz5mtu349eafhqv87wksze9s4seshdtm3j"
 entry_point_contract_address = "bbn1g0uuysdqydrmfum8ctn7whlevuwydeqvuw0kumqj8773ru5aglwq6vww30"
 
 [tx-hashes]
-store_ibc_transfer_adapter_tx_hash = "17d5dc5687a916ac235cdfeb17fb4caa9dfa0e5a5137e9f4935a1d6d8590b51d"
-instantiate_ibc_transfer_adapter_tx_hash = "a564b64d159005e1795c5ff501c9159486109941849ea6c968a829512d683627"
-store_swap_adapter_babylon-tower_tx_hash = "e4064eaa6a43dd9fe65e89be605dc411aec81bee83a05a3dae9db3628c81f28f"
-instantiate_swap_adapter_babylon-tower_tx_hash = "7f5efc90c8850518e12c77f192a602d37fa67857d975e67212f87362baa62b20"
-store_entry_point_tx_hash = "a40a7f1e2924d35d3c4f2c574f217dfd70cfb6805f92ab0bce481f5fc3152770"
-instantiate_entry_point_tx_hash = "deedcbdce8b37df00e561ded7361adc3e7be4c0caa621d33e211b6804e79a8af"
+store_ibc_transfer_adapter_tx_hash = "d3805112c9e32ff40a79db8fa935be6ec91c08b614f64a809ff56b74eedd1127"
+instantiate_ibc_transfer_adapter_tx_hash = "75649d43ccf52044a7552e8ae4ef3285f4869915a023b5bf40bc8ff26c5b1852"
+store_swap_adapter_testnet-babylon-tower_tx_hash = "cf86d654d476e651a38ad0f779ce15dc3b0b3d2b950e534e7fad6807602c07a6"
+instantiate_swap_adapter_testnet-babylon-tower_tx_hash = "9f586d4a220f825caa6c74b6a9b0a554d4531c14f9444bcc4c8a305ae5fa8773"
+store_entry_point_tx_hash = "63ce5cfe900b9122ee160590d145d048049baea94fd14f523c3990a88af8ccd1"
+instantiate_entry_point_tx_hash = "94411e1178f4f3031a4b1557a52d48e276bb2618bd276e7913f669a1ec45e284"

--- a/scripts/configs/babylon.toml
+++ b/scripts/configs/babylon.toml
@@ -1,0 +1,38 @@
+# Enter your mnemonic here
+MNEMONIC = "<YOUR MNEMONIC HERE>"
+
+# Commit Hash of the commit used to build the contracts
+COMMIT_HASH = "<COMMIT HASH HERE>"
+
+MAINNET_REST_URL = "https://babylon-api.polkachu.com" 
+MAINNET_RPC_URL = "https://babylon-rpc.polkachu.com"
+MAINNET_CHAIN_ID = "bbn-1"
+
+TESTNET_REST_URL = "https://babylon-testnet-api.nodes.guru"
+TESTNET_RPC_URL = "https://babylon-testnet-rpc.nodes.guru"
+TESTNET_CHAIN_ID = "bbn-test-5"
+
+ADDRESS_PREFIX = "bbn"
+DENOM = "ubbn"
+GAS_PRICE = 0.007
+
+# Contract Paths
+ENTRY_POINT_CONTRACT_PATH = "../artifacts/skip_go_entry_point.wasm"
+IBC_TRANSFER_ADAPTER_PATH = "../artifacts/skip_go_ibc_adapter_ibc_callbacks.wasm"
+
+# SALT USED TO GENERATE A DETERMINSTIC ADDRESS
+SALT = "1"
+
+# @DEV MUST CHANGE SALT ACCORDINGLY TO OBTAIN THIS PRE GENERATED ADDRESS
+ENTRY_POINT_PRE_GENERATED_ADDRESS = "<PRE GENERATED ADDRESS HERE>"
+
+# ADDRESS GRANTED PERMISSION BY GOVERNANCE TO UPLOAD CONTRACATS
+PERMISSIONED_UPLOADER_ADDRESS = "bbn1raa4kyx5ypz75qqk3566c6slx2mw3qzsrlp9j9"
+
+[[swap_venues]]
+name = "babylon-tower"
+swap_adapter_path = "../artifacts/skip_go_swap_adapter_astroport.wasm"
+
+[[testnet_swap_venues]]
+name = "testnet-babylon-tower"
+swap_adapter_path = "../artifacts/skip_go_swap_adapter_astroport.wasm"

--- a/scripts/configs/cosmoshub.toml
+++ b/scripts/configs/cosmoshub.toml
@@ -1,0 +1,30 @@
+# Enter your mnemonic here
+MNEMONIC = "<YOUR MNEMONIC HERE>"
+
+# Commit Hash of the commit used to build the contracts
+COMMIT_HASH = "<COMMIT HASH HERE>"
+
+MAINNET_REST_URL = "https://rest.cosmoshub.goldenratiostaking.net" 
+MAINNET_RPC_URL = "https://cosmos-rpc.polkachu.com"
+MAINNET_CHAIN_ID = "cosmoshub-4"
+
+TESTNET_REST_URL = "https://rest.provider-sentry-01.ics-testnet.polypore.xyz"
+TESTNET_RPC_URL = "https://rpc.provider-sentry-01.ics-testnet.polypore.xyz"
+TESTNET_CHAIN_ID = "provider"
+
+ADDRESS_PREFIX = "cosmos"
+DENOM = "uatom"
+GAS_PRICE = 0.01
+
+# Contract Paths
+ENTRY_POINT_CONTRACT_PATH = "../artifacts/skip_go_entry_point.wasm"
+IBC_TRANSFER_ADAPTER_PATH = "../artifacts/skip_go_ibc_adapter_ibc_callbacks.wasm"
+
+# SALT USED TO GENERATE A DETERMINSTIC ADDRESS
+SALT = "1"
+
+# @DEV MUST CHANGE SALT ACCORDINGLY TO OBTAIN THIS PRE GENERATED ADDRESS
+ENTRY_POINT_PRE_GENERATED_ADDRESS = "<PRE GENERATED ADDRESS HERE>"
+
+# ADDRESS GRANTED PERMISSION BY GOVERNANCE TO UPLOAD CONTRACATS
+PERMISSIONED_UPLOADER_ADDRESS = "cosmos1raa4kyx5ypz75qqk3566c6slx2mw3qzs5ps5du"

--- a/scripts/configs/ledger.toml
+++ b/scripts/configs/ledger.toml
@@ -1,0 +1,37 @@
+# Enter your mnemonic here
+MNEMONIC = "<YOUR MNEMONIC HERE>"
+
+# Commit Hash of the commit used to build the contracts
+COMMIT_HASH = "<COMMIT HASH HERE>"
+
+MAINNET_REST_URL = "http://rpc-mainnet.lb-mgt.com:1317"
+MAINNET_RPC_URL = "https://rpc-mainnet.lb-mgt.com"
+MAINNET_CHAIN_ID = "ledger-mainnet-1"
+
+TESTNET_REST_URL = "http://rpc-gastald.lb-mgt.com:1317"
+TESTNET_RPC_URL = "https://rpc-gastald.lb-mgt.com"
+TESTNET_CHAIN_ID = "ledger-testnet-1"
+
+ADDRESS_PREFIX = "lom"
+DENOM = "ulom"
+GAS_PRICE = 100
+
+# Contract Paths
+ENTRY_POINT_CONTRACT_PATH = "../artifacts/skip_go_entry_point.wasm"
+IBC_TRANSFER_ADAPTER_PATH = "../artifacts/skip_go_ibc_adapter_ibc_callbacks.wasm"
+
+# SALT USED TO GENERATE A DETERMINSTIC ADDRESS
+SALT = "1"
+
+# @DEV MUST CHANGE SALT ACCORDINGLY TO OBTAIN THIS PRE GENERATED ADDRESS
+ENTRY_POINT_PRE_GENERATED_ADDRESS = "<PRE GENERATED ADDRESS HERE>"
+
+[[swap_venues]]
+name = "ledger-lbtc-convert"
+mantra_pool_manager_address = "lom14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s9fver0"
+swap_adapter_path = "../artifacts/skip_go_swap_adapter_mantra_dex.wasm"
+
+[[testnet_swap_venues]]
+name = "testnet-ledger-lbtc-convert"
+mantra_pool_manager_address = "lom14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s9fver0"
+swap_adapter_path = "../artifacts/skip_go_swap_adapter_mantra_dex.wasm"


### PR DESCRIPTION
## This PR
- Sets drop factory import to a specific commit, fixing CI workflows
- Adds babylon, lombard, and cosmos hub config files to make deployment easier
- Updates deployed babylon contracts to use ibc callbacks adapter