### PR TITLE
fix: add injective adapter fixes

### DIFF
--- a/contracts/adapters/swap/injective/src/contract.rs
+++ b/contracts/adapters/swap/injective/src/contract.rs
@@ -50,14 +50,14 @@ pub enum InjectiveQueryMsg {
 
 #[cw_serde]
 pub struct FPCoin {
-    pub amount: Uint128,
+    pub amount: String,
     pub denom: String,
 }
 
 #[cw_serde]
 pub struct OutputQuantityResponse {
     pub result_quantity: Uint128,
-    pub expected_fees: Vec<Coin>,
+    pub expected_fees: Vec<FPCoin>,
 }
 
 #[cw_serde]

--- a/contracts/adapters/swap/injective/src/contract.rs
+++ b/contracts/adapters/swap/injective/src/contract.rs
@@ -49,6 +49,12 @@ pub enum InjectiveQueryMsg {
 }
 
 #[cw_serde]
+pub struct FPCoin {
+    pub amount: Uint128,
+    pub denom: String,
+}
+
+#[cw_serde]
 pub struct OutputQuantityResponse {
     pub result_quantity: Uint128,
     pub expected_fees: Vec<Coin>,
@@ -57,7 +63,7 @@ pub struct OutputQuantityResponse {
 #[cw_serde]
 pub struct InputQuantityResponse {
     pub result_quantity: Uint128,
-    pub expected_fees: Vec<Coin>,
+    pub expected_fees: Vec<FPCoin>,
 }
 
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
@@ -136,7 +142,7 @@ fn execute_swap(
 
     let injective_msg = InjectiveExecuteMsg::SwapMinOutput {
         target_denom: target_denom.clone(),
-        min_output_quantity: "0".to_string(),
+        min_output_quantity: "1".to_string(),
     };
 
     let injective_wasm_msg = wasm_execute(injective, &injective_msg, vec![coin_in])?;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces `Vec<Coin>` with `Vec<FPCoin>` in query responses and sets swap `min_output_quantity` to "1".
> 
> - **Injective swap contract (`contracts/adapters/swap/injective/src/contract.rs`)**:
>   - Change query response fee types:
>     - `OutputQuantityResponse.expected_fees`: `Vec<Coin>` -> `Vec<FPCoin>`.
>     - `InputQuantityResponse.expected_fees`: `Vec<Coin>` -> `Vec<FPCoin>`.
>     - Add `FPCoin { amount: String, denom: String }`.
>   - Execution behavior:
>     - Set `SwapMinOutput.min_output_quantity` from `"0"` to `"1"` in `execute_swap`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1f814145b91c9e12d38b0f1c6ebb2b342f996a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->