### PR TITLE
ECO2-60: Support Oroswap with new Swapvenue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,17 +1607,17 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 [[package]]
 name = "drop-factory"
 version = "1.0.0"
-source = "git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes#781fd3add565ee02a2dfb568e6ab49b7c5e09b2f"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
 dependencies = [
  "cosmwasm-schema 1.5.11",
  "cosmwasm-std 1.5.11",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
- "drop-helpers",
- "drop-macros",
- "drop-puppeteer-base",
- "drop-staking-base",
+ "drop-helpers 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-macros 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-puppeteer-base 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-staking-base 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
  "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
  "semver 1.0.26",
  "thiserror 1.0.69",
@@ -1644,9 +1644,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "drop-helpers"
+version = "1.0.0"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
+dependencies = [
+ "cosmos-sdk-proto 0.20.0",
+ "cosmwasm-schema 1.5.11",
+ "cosmwasm-std 1.5.11",
+ "cw-storage-plus 1.2.0",
+ "hex",
+ "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
+ "prost 0.12.6",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "sha3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "drop-macros"
 version = "1.0.0"
 source = "git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes#781fd3add565ee02a2dfb568e6ab49b7c5e09b2f"
+dependencies = [
+ "cosmwasm-schema 1.5.11",
+ "cosmwasm-std 1.5.11",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "drop-macros"
+version = "1.0.0"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
 dependencies = [
  "cosmwasm-schema 1.5.11",
  "cosmwasm-std 1.5.11",
@@ -1667,6 +1698,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "drop-proto"
+version = "1.0.0"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
+dependencies = [
+ "cosmwasm-std 1.5.11",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "tendermint-proto 0.34.1",
+]
+
+[[package]]
 name = "drop-puppeteer-base"
 version = "1.0.0"
 source = "git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes#781fd3add565ee02a2dfb568e6ab49b7c5e09b2f"
@@ -1676,7 +1718,28 @@ dependencies = [
  "cosmwasm-std 1.5.11",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
- "drop-helpers",
+ "drop-helpers 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
+ "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "schemars",
+ "semver 1.0.26",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "drop-puppeteer-base"
+version = "1.0.0"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
+dependencies = [
+ "cosmos-sdk-proto 0.20.0",
+ "cosmwasm-schema 1.5.11",
+ "cosmwasm-std 1.5.11",
+ "cw-ownable",
+ "cw-storage-plus 1.2.0",
+ "drop-helpers 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
  "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
  "prost 0.12.6",
  "prost-types 0.12.6",
@@ -1701,10 +1764,36 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "drop-helpers",
- "drop-macros",
- "drop-proto",
- "drop-puppeteer-base",
+ "drop-helpers 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
+ "drop-macros 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
+ "drop-proto 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
+ "drop-puppeteer-base 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
+ "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
+ "optfield",
+ "prost 0.12.6",
+ "semver 1.0.26",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "drop-staking-base"
+version = "1.0.0"
+source = "git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67#899ec67f9503742b1f0b8846e551d2e3f95e44a9"
+dependencies = [
+ "astroport 3.12.2",
+ "cosmos-sdk-proto 0.20.0",
+ "cosmwasm-schema 1.5.11",
+ "cosmwasm-std 1.5.11",
+ "cw-ownable",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw721 0.18.0",
+ "cw721-base 0.18.0",
+ "drop-helpers 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-macros 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-proto 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
+ "drop-puppeteer-base 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?rev=899ec67)",
  "neutron-sdk 0.10.0 (git+https://github.com/neutron-org/neutron-sdk?branch=feat/proposal-votes)",
  "optfield",
  "prost 0.12.6",
@@ -3755,7 +3844,7 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "drop-factory",
- "drop-staking-base",
+ "drop-staking-base 1.0.0 (git+https://github.com/hadronlabs-org/drop-contracts.git?branch=feat/audit-fixes)",
  "skip",
  "test-case",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "oroswap-circular-buffer"
+version = "1.1.0"
+source = "git+https://github.com/oroswap/oroswap-core?tag=v1.1.0#f5374397eff6284b8960452fdc0c8271368e1b62"
+dependencies = [
+ "cosmwasm-schema 1.5.11",
+ "cosmwasm-std 1.5.11",
+ "cw-storage-plus 1.2.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "oroswap-core"
+version = "1.1.0"
+source = "git+https://github.com/oroswap/oroswap-core?tag=v1.1.0#f5374397eff6284b8960452fdc0c8271368e1b62"
+dependencies = [
+ "cosmos-sdk-proto 0.19.0",
+ "cosmwasm-schema 1.5.11",
+ "cosmwasm-std 1.5.11",
+ "cw-asset",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw20 1.1.2",
+ "itertools 0.12.1",
+ "oroswap-circular-buffer",
+ "prost 0.11.9",
+ "uint",
+]
+
+[[package]]
 name = "osmosis-std"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3559,6 +3588,7 @@ dependencies = [
  "elys-std",
  "ibc-proto 0.32.1",
  "neutron-proto",
+ "oroswap-core",
  "osmosis-std",
  "thiserror 1.0.69",
  "white-whale-std",
@@ -3818,6 +3848,22 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
+ "skip",
+ "test-case",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "skip-go-swap-adapter-oroswap"
+version = "0.3.0"
+dependencies = [
+ "cosmwasm-schema 1.5.11",
+ "cosmwasm-std 1.5.11",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
+ "cw20 1.1.2",
+ "oroswap-core",
  "skip",
  "test-case",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ cw-multi-test        = "0.20.0"
 hpl-interface        = { git = "https://github.com/many-things/cw-hyperlane.git", branch = "main", features = ["library"] }
 ibc-proto            = { version = "0.32.1", default-features = false }
 lido-satellite       = { git = "https://github.com/hadronlabs-org/lido-satellite", branch = "main", features = ["library"] }
-drop-factory         = { git = "https://github.com/hadronlabs-org/drop-contracts.git", branch = "feat/audit-fixes", features = ["library"] }
+drop-factory         = { git = "https://github.com/hadronlabs-org/drop-contracts.git", rev = "899ec67", features = ["library"] }
 drop-staking-base    = { git = "https://github.com/hadronlabs-org/drop-contracts.git", branch = "feat/audit-fixes", features = ["library"] }
 mockall              = "0.12.1"
 neutron-proto        = { version = "0.1.1", default-features = false, features = ["cosmwasm"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ keywords      = ["cosmwasm"]
 [workspace.dependencies]
 astroport            = "2.9"
 astrovault           = "0.1.8"
+oroswap              = { package = "oroswap-core", git = "https://github.com/oroswap/oroswap-core", tag = "v1.1.0" }
 dexter               = "1.4.0"
 dexter-vault         = "1.1.0"
 dexter-stable-pool   = "1.1.1"

--- a/contracts/adapters/ibc/neutron-transfer/src/contract.rs
+++ b/contracts/adapters/ibc/neutron-transfer/src/contract.rs
@@ -230,7 +230,7 @@ pub fn sudo(deps: DepsMut, env: Env, msg: TransferSudoMsg) -> ContractResult<Res
 //////////////////////
 
 // Helper function to get the ack_id (channel id, sequence id) from a RequestPacket
-fn get_ack_id(req: &RequestPacket) -> ContractResult<AckID> {
+fn get_ack_id(req: &RequestPacket) -> ContractResult<AckID<'_>> {
     // Get the channel id and sequence id from the request packet
     let channel_id = req
         .source_channel

--- a/contracts/adapters/swap/injective/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/injective/tests/test_execute_swap.rs
@@ -54,7 +54,7 @@ struct Params {
                 id: 0,
                 msg: WasmMsg::Execute {
                     contract_addr: "injective_swap_contract_address".to_string(),
-                    msg: to_json_binary(&InjectiveExecuteMsg::SwapMinOutput { 
+                    msg: to_json_binary(&InjectiveExecuteMsg::SwapMinOutput {
                         min_output_quantity: "0".to_string(),
                         target_denom: "ua".to_string(),
                     })?,
@@ -104,7 +104,7 @@ struct Params {
                 id: 0,
                 msg: WasmMsg::Execute {
                     contract_addr: "injective_swap_contract_address".to_string(),
-                    msg: to_json_binary(&InjectiveExecuteMsg::SwapMinOutput { 
+                    msg: to_json_binary(&InjectiveExecuteMsg::SwapMinOutput {
                         min_output_quantity: "0".to_string(),
                         target_denom: "un".to_string(),
                     })?,

--- a/contracts/adapters/swap/oroswap/Cargo.toml
+++ b/contracts/adapters/swap/oroswap/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name          = "skip-go-swap-adapter-oroswap"
+version       = { workspace = true }
+rust-version  = { workspace = true }
+authors       = { workspace = true }
+edition       = { workspace = true }
+license       = { workspace = true }
+homepage      = { workspace = true }
+repository    = { workspace = true }
+documentation = { workspace = true }
+keywords      = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+oroswap          = { workspace = true }
+cosmwasm-schema  = { workspace = true }
+cosmwasm-std     = { workspace = true }
+cw2              = { workspace = true }
+cw20             = { workspace = true }
+cw-storage-plus  = { workspace = true }
+cw-utils         = { workspace = true }
+skip             = { workspace = true }
+thiserror        = { workspace = true }
+
+[dev-dependencies]
+test-case        = { workspace = true }

--- a/contracts/adapters/swap/oroswap/README.md
+++ b/contracts/adapters/swap/oroswap/README.md
@@ -1,0 +1,108 @@
+# Oroswap Swap Adapter Contract
+
+The Oroswap swap adapter contract is responsible for:
+1. Taking the standardized entry point swap operations message format and converting it to Oroswap pair swap message format.
+2. Swapping by dispatching swaps to Oroswap pair contracts.
+3. Providing query methods that can be called by the entry point contract (generally, to any external actor) to simulate multi-hop swaps that either specify an exact amount in (estimating how much would be received from the swap) or an exact amount out (estimating how much is required to get the specified amount out).
+
+Oroswap is an Astroport fork deployed on ZIGChain. Although the upstream Astroport adapter served as a starting template, this adapter depends on the [`oroswap-core`](https://github.com/oroswap/oroswap-core) types and dispatches `OroswapPoolSwap` (not `AstroportPoolSwap`) so that any future divergence is caught at compile time rather than silently at runtime. The pair-level wire format (`ExecuteMsg::Swap`, `Cw20HookMsg::Swap`, `QueryMsg::Simulation`, `QueryMsg::ReverseSimulation`, `MAX_ALLOWED_SLIPPAGE`) is currently identical to Astroport 2.9.
+
+Note: Swap adapter contracts expect to be called by an entry point contract that provides basic validation and minimum amount out safety guarantees for the caller. There are no slippage guarantees provided by swap adapter contracts.
+
+WARNING: Do not send funds directly to the contract without calling one of its functions. Funds sent directly to the contract do not trigger any contract logic that performs validation / safety checks (as the Cosmos SDK handles direct fund transfers in the `Bank` module and not the `Wasm` module). There are no explicit recovery mechanisms for accidentally sent funds.
+
+## InstantiateMsg
+
+Instantiates a new Oroswap swap adapter contract using the Entrypoint contract address provided in the instantiation message.
+
+``` json
+{
+    "entry_point_contract_address": "zig1..."
+}
+```
+
+## ExecuteMsg
+
+### `swap`
+
+Swaps the coin sent using the operations provided. Each `pool` is an Oroswap pair contract address. The adapter dispatches a separate `OroswapPoolSwap` self-call per operation followed by `TransferFundsBack` at the end.
+
+``` json
+{
+    "swap": {
+        "operations": [
+            {
+                "pool": "zig1...",
+                "denom_in": "uzig",
+                "denom_out": "coin.zig1<issuer>.husky"
+            },
+            {
+                "pool": "zig1...",
+                "denom_in": "coin.zig1<issuer>.husky",
+                "denom_out": "coin.zig1<issuer>.bitbull"
+            }
+        ]
+    }
+}
+```
+
+Note on denoms: native tokenfactory denoms on ZIGChain follow the `coin.<creator_addr>.<subdenom>` format (rather than the Cosmos SDK standard `factory/<creator>/<subdenom>`). LP tokens issued by Oroswap pairs are also native tokenfactory denoms, not CW20 contracts.
+
+### `transfer_funds_back`
+
+Transfers all contract funds to the address provided. Called by the swap adapter contract itself to send the assets received from swapping back to the entry point contract.
+
+Note: This function can be called by anyone as the contract is assumed to have no balance before/after it's called by the entry point contract. Do not send funds directly to this contract without calling a function.
+
+``` json
+{
+    "transfer_funds_back": {
+        "swapper": "zig1...",
+        "return_denom": "coin.zig1<issuer>.bitbull"
+    }
+}
+```
+
+## QueryMsg
+
+### `simulate_swap_exact_asset_out`
+
+Returns the asset in required to receive the `asset_out` specified in the call (swapped through the `swap_operations` provided). Each pair contract's `ReverseSimulation` query is called in reverse order.
+
+``` json
+{
+    "simulate_swap_exact_asset_out": {
+        "asset_out": {
+            "native": { "denom": "uzig", "amount": "200000" }
+        },
+        "swap_operations": [
+            {
+                "pool": "zig1...",
+                "denom_in": "coin.zig1<issuer>.husky",
+                "denom_out": "uzig"
+            }
+        ]
+    }
+}
+```
+
+### `simulate_swap_exact_asset_in`
+
+Returns the asset out that would be received from swapping the `asset_in` specified in the call (swapped through the `swap_operations` provided). Each pair contract's `Simulation` query is called in order.
+
+``` json
+{
+    "simulate_swap_exact_asset_in": {
+        "asset_in": {
+            "native": { "denom": "uzig", "amount": "100" }
+        },
+        "swap_operations": [
+            {
+                "pool": "zig1...",
+                "denom_in": "uzig",
+                "denom_out": "coin.zig1<issuer>.husky"
+            }
+        ]
+    }
+}
+```

--- a/contracts/adapters/swap/oroswap/src/bin/oroswap-schema.rs
+++ b/contracts/adapters/swap/oroswap/src/bin/oroswap-schema.rs
@@ -1,0 +1,10 @@
+use cosmwasm_schema::write_api;
+use skip::swap::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg
+    }
+}

--- a/contracts/adapters/swap/oroswap/src/contract.rs
+++ b/contracts/adapters/swap/oroswap/src/contract.rs
@@ -1,0 +1,639 @@
+use crate::{
+    error::{ContractError, ContractResult},
+    state::ENTRY_POINT_CONTRACT_ADDRESS,
+};
+use cosmwasm_std::{
+    entry_point, from_json, to_json_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo,
+    Response, Uint128, WasmMsg,
+};
+use cw2::set_contract_version;
+use cw20::{Cw20Coin, Cw20ReceiveMsg};
+use cw_utils::one_coin;
+use oroswap::pair::{
+    Cw20HookMsg as PairCw20HookMsg, ExecuteMsg as PairExecuteMsg, QueryMsg as PairQueryMsg,
+    ReverseSimulationResponse, SimulationResponse, MAX_ALLOWED_SLIPPAGE,
+};
+use skip::{
+    asset::{get_current_asset_available, Asset},
+    swap::{
+        execute_transfer_funds_back, get_ask_denom_for_routes, Cw20HookMsg, ExecuteMsg,
+        InstantiateMsg, MigrateMsg, QueryMsg, Route, SimulateSmartSwapExactAssetInResponse,
+        SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse, SwapOperation,
+    },
+};
+
+const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+///////////////
+/// MIGRATE ///
+///////////////
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> ContractResult<Response> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    let checked_entry_point_contract_address =
+        deps.api.addr_validate(&msg.entry_point_contract_address)?;
+
+    ENTRY_POINT_CONTRACT_ADDRESS.save(deps.storage, &checked_entry_point_contract_address)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "migrate")
+        .add_attribute(
+            "entry_point_contract_address",
+            checked_entry_point_contract_address.to_string(),
+        ))
+}
+
+/////////////////
+// INSTANTIATE //
+/////////////////
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> ContractResult<Response> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    let checked_entry_point_contract_address =
+        deps.api.addr_validate(&msg.entry_point_contract_address)?;
+
+    ENTRY_POINT_CONTRACT_ADDRESS.save(deps.storage, &checked_entry_point_contract_address)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "instantiate")
+        .add_attribute(
+            "entry_point_contract_address",
+            checked_entry_point_contract_address.to_string(),
+        ))
+}
+
+/////////////
+// RECEIVE //
+/////////////
+
+pub fn receive_cw20(
+    deps: DepsMut,
+    env: Env,
+    mut info: MessageInfo,
+    cw20_msg: Cw20ReceiveMsg,
+) -> ContractResult<Response> {
+    let sent_asset = Asset::Cw20(Cw20Coin {
+        address: info.sender.to_string(),
+        amount: cw20_msg.amount,
+    });
+    sent_asset.validate(&deps, &env, &info)?;
+
+    info.sender = deps.api.addr_validate(&cw20_msg.sender)?;
+
+    match from_json(&cw20_msg.msg)? {
+        Cw20HookMsg::Swap { operations } => execute_swap(deps, env, info, operations),
+    }
+}
+
+///////////////
+/// EXECUTE ///
+///////////////
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> ContractResult<Response> {
+    match msg {
+        ExecuteMsg::Receive(cw20_msg) => receive_cw20(deps, env, info, cw20_msg),
+        ExecuteMsg::Swap { operations } => {
+            one_coin(&info)?;
+            execute_swap(deps, env, info, operations)
+        }
+        ExecuteMsg::TransferFundsBack {
+            swapper,
+            return_denom,
+        } => Ok(execute_transfer_funds_back(
+            deps,
+            env,
+            info,
+            swapper,
+            return_denom,
+        )?),
+        ExecuteMsg::OroswapPoolSwap { operation } => {
+            execute_oroswap_pool_swap(deps, env, info, operation)
+        }
+        _ => {
+            unimplemented!()
+        }
+    }
+}
+
+fn execute_swap(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    operations: Vec<SwapOperation>,
+) -> ContractResult<Response> {
+    let entry_point_contract_address = ENTRY_POINT_CONTRACT_ADDRESS.load(deps.storage)?;
+
+    if info.sender != entry_point_contract_address {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let mut response: Response = Response::new().add_attribute("action", "execute_swap");
+
+    for operation in &operations {
+        let swap_msg = WasmMsg::Execute {
+            contract_addr: env.contract.address.to_string(),
+            msg: to_json_binary(&ExecuteMsg::OroswapPoolSwap {
+                operation: operation.clone(),
+            })?,
+            funds: vec![],
+        };
+        response = response.add_message(swap_msg);
+    }
+
+    let return_denom = match operations.last() {
+        Some(last_op) => last_op.denom_out.clone(),
+        None => return Err(ContractError::SwapOperationsEmpty),
+    };
+
+    let transfer_funds_back_msg = WasmMsg::Execute {
+        contract_addr: env.contract.address.to_string(),
+        msg: to_json_binary(&ExecuteMsg::TransferFundsBack {
+            swapper: entry_point_contract_address,
+            return_denom,
+        })?,
+        funds: vec![],
+    };
+
+    Ok(response
+        .add_message(transfer_funds_back_msg)
+        .add_attribute("action", "dispatch_swaps_and_transfer_back"))
+}
+
+fn execute_oroswap_pool_swap(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    operation: SwapOperation,
+) -> ContractResult<Response> {
+    if info.sender != env.contract.address {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let offer_asset = get_current_asset_available(&deps, &env, &operation.denom_in)?;
+
+    if offer_asset.amount().is_zero() {
+        return Err(ContractError::NoOfferAssetAmount);
+    }
+
+    let msg = match offer_asset {
+        Asset::Native(_) => to_json_binary(&PairExecuteMsg::Swap {
+            offer_asset: offer_asset.into_oroswap_asset(deps.api)?,
+            ask_asset_info: None,
+            belief_price: None,
+            max_spread: Some(MAX_ALLOWED_SLIPPAGE.parse::<Decimal>()?),
+            to: None,
+        })?,
+        Asset::Cw20(_) => to_json_binary(&PairCw20HookMsg::Swap {
+            ask_asset_info: None,
+            belief_price: None,
+            max_spread: Some(MAX_ALLOWED_SLIPPAGE.parse::<Decimal>()?),
+            to: None,
+        })?,
+    };
+
+    let swap_msg = offer_asset.into_wasm_msg(operation.pool, msg)?;
+
+    Ok(Response::new()
+        .add_message(swap_msg)
+        .add_attribute("action", "dispatch_oroswap_pool_swap"))
+}
+
+/////////////
+/// QUERY ///
+/////////////
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
+    match msg {
+        QueryMsg::SimulateSwapExactAssetIn {
+            asset_in,
+            swap_operations,
+        } => to_json_binary(&query_simulate_swap_exact_asset_in(
+            deps,
+            asset_in,
+            swap_operations,
+        )?),
+        QueryMsg::SimulateSwapExactAssetOut {
+            asset_out,
+            swap_operations,
+        } => to_json_binary(&query_simulate_swap_exact_asset_out(
+            deps,
+            asset_out,
+            swap_operations,
+        )?),
+        QueryMsg::SimulateSwapExactAssetInWithMetadata {
+            asset_in,
+            swap_operations,
+            include_spot_price,
+        } => to_json_binary(&query_simulate_swap_exact_asset_in_with_metadata(
+            deps,
+            asset_in,
+            swap_operations,
+            include_spot_price,
+        )?),
+        QueryMsg::SimulateSwapExactAssetOutWithMetadata {
+            asset_out,
+            swap_operations,
+            include_spot_price,
+        } => to_json_binary(&query_simulate_swap_exact_asset_out_with_metadata(
+            deps,
+            asset_out,
+            swap_operations,
+            include_spot_price,
+        )?),
+        QueryMsg::SimulateSmartSwapExactAssetIn { routes, .. } => {
+            let ask_denom = get_ask_denom_for_routes(&routes)?;
+
+            to_json_binary(&query_simulate_smart_swap_exact_asset_in(
+                deps, ask_denom, routes,
+            )?)
+        }
+        QueryMsg::SimulateSmartSwapExactAssetInWithMetadata {
+            asset_in,
+            routes,
+            include_spot_price,
+        } => {
+            let ask_denom = get_ask_denom_for_routes(&routes)?;
+
+            to_json_binary(&query_simulate_smart_swap_exact_asset_in_with_metadata(
+                deps,
+                asset_in,
+                ask_denom,
+                routes,
+                include_spot_price,
+            )?)
+        }
+    }
+    .map_err(From::from)
+}
+
+fn query_simulate_swap_exact_asset_in(
+    deps: Deps,
+    asset_in: Asset,
+    swap_operations: Vec<SwapOperation>,
+) -> ContractResult<Asset> {
+    let Some(first_op) = swap_operations.first() else {
+        return Err(ContractError::SwapOperationsEmpty);
+    };
+
+    if asset_in.denom() != first_op.denom_in {
+        return Err(ContractError::CoinInDenomMismatch);
+    }
+
+    let (asset_out, _) = simulate_swap_exact_asset_in(deps, asset_in, swap_operations, false)?;
+
+    Ok(asset_out)
+}
+
+fn query_simulate_swap_exact_asset_out(
+    deps: Deps,
+    asset_out: Asset,
+    swap_operations: Vec<SwapOperation>,
+) -> ContractResult<Asset> {
+    let Some(last_op) = swap_operations.last() else {
+        return Err(ContractError::SwapOperationsEmpty);
+    };
+
+    if asset_out.denom() != last_op.denom_out {
+        return Err(ContractError::CoinOutDenomMismatch);
+    }
+
+    let (asset_in, _) = simulate_swap_exact_asset_out(deps, asset_out, swap_operations, false)?;
+
+    Ok(asset_in)
+}
+
+fn query_simulate_smart_swap_exact_asset_in(
+    deps: Deps,
+    ask_denom: String,
+    routes: Vec<Route>,
+) -> ContractResult<Asset> {
+    let (asset_out, _) = simulate_smart_swap_exact_asset_in(deps, ask_denom, routes, false)?;
+
+    Ok(asset_out)
+}
+
+fn query_simulate_swap_exact_asset_in_with_metadata(
+    deps: Deps,
+    asset_in: Asset,
+    swap_operations: Vec<SwapOperation>,
+    include_spot_price: bool,
+) -> ContractResult<SimulateSwapExactAssetInResponse> {
+    let Some(first_op) = swap_operations.first() else {
+        return Err(ContractError::SwapOperationsEmpty);
+    };
+
+    if asset_in.denom() != first_op.denom_in {
+        return Err(ContractError::CoinInDenomMismatch);
+    }
+
+    let mut include_sim_resps = false;
+    if include_spot_price {
+        include_sim_resps = true;
+    }
+
+    let (asset_out, sim_resps) = simulate_swap_exact_asset_in(
+        deps,
+        asset_in.clone(),
+        swap_operations.clone(),
+        include_sim_resps,
+    )?;
+
+    let mut response = SimulateSwapExactAssetInResponse {
+        asset_out,
+        spot_price: None,
+    };
+
+    if include_spot_price {
+        response.spot_price = Some(calculate_spot_price_from_simulation_responses(
+            deps,
+            asset_in,
+            swap_operations,
+            sim_resps,
+        )?)
+    }
+
+    Ok(response)
+}
+
+fn query_simulate_swap_exact_asset_out_with_metadata(
+    deps: Deps,
+    asset_out: Asset,
+    swap_operations: Vec<SwapOperation>,
+    include_spot_price: bool,
+) -> ContractResult<SimulateSwapExactAssetOutResponse> {
+    let Some(last_op) = swap_operations.last() else {
+        return Err(ContractError::SwapOperationsEmpty);
+    };
+
+    if asset_out.denom() != last_op.denom_out {
+        return Err(ContractError::CoinOutDenomMismatch);
+    }
+
+    let mut include_sim_resps = false;
+    if include_spot_price {
+        include_sim_resps = true;
+    }
+
+    let (asset_in, sim_resps) = simulate_swap_exact_asset_out(
+        deps,
+        asset_out.clone(),
+        swap_operations.clone(),
+        include_sim_resps,
+    )?;
+
+    let mut response = SimulateSwapExactAssetOutResponse {
+        asset_in,
+        spot_price: None,
+    };
+
+    if include_spot_price {
+        response.spot_price = Some(calculate_spot_price_from_reverse_simulation_responses(
+            deps,
+            asset_out,
+            swap_operations,
+            sim_resps,
+        )?)
+    }
+
+    Ok(response)
+}
+
+fn query_simulate_smart_swap_exact_asset_in_with_metadata(
+    deps: Deps,
+    asset_in: Asset,
+    ask_denom: String,
+    routes: Vec<Route>,
+    include_spot_price: bool,
+) -> ContractResult<SimulateSmartSwapExactAssetInResponse> {
+    let (asset_out, simulation_responses) =
+        simulate_smart_swap_exact_asset_in(deps, ask_denom, routes.clone(), include_spot_price)?;
+
+    let mut response = SimulateSmartSwapExactAssetInResponse {
+        asset_out,
+        spot_price: None,
+    };
+
+    if include_spot_price {
+        response.spot_price = Some(calculate_weighted_spot_price_from_simulation_responses(
+            deps,
+            asset_in,
+            routes,
+            simulation_responses,
+        )?)
+    }
+
+    Ok(response)
+}
+
+fn assert_max_spread(return_amount: Uint128, spread_amount: Uint128) -> ContractResult<()> {
+    let max_spread = MAX_ALLOWED_SLIPPAGE.parse::<Decimal>()?;
+    if Decimal::from_ratio(spread_amount, return_amount + spread_amount) > max_spread {
+        return Err(ContractError::MaxSpreadAssertion {});
+    }
+    Ok(())
+}
+
+fn simulate_swap_exact_asset_in(
+    deps: Deps,
+    asset_in: Asset,
+    swap_operations: Vec<SwapOperation>,
+    include_responses: bool,
+) -> ContractResult<(Asset, Vec<SimulationResponse>)> {
+    let (asset_out, responses) = swap_operations.iter().try_fold(
+        (asset_in, Vec::new()),
+        |(asset_out, mut responses), operation| -> Result<_, ContractError> {
+            let oroswap_offer_asset = asset_out.into_oroswap_asset(deps.api)?;
+
+            let res: SimulationResponse = deps.querier.query_wasm_smart(
+                &operation.pool,
+                &PairQueryMsg::Simulation {
+                    offer_asset: oroswap_offer_asset,
+                    ask_asset_info: None,
+                },
+            )?;
+
+            assert_max_spread(res.return_amount, res.spread_amount)?;
+
+            if include_responses {
+                responses.push(res.clone());
+            }
+
+            Ok((
+                Asset::new(deps.api, &operation.denom_out, res.return_amount),
+                responses,
+            ))
+        },
+    )?;
+
+    Ok((asset_out, responses))
+}
+
+fn simulate_swap_exact_asset_out(
+    deps: Deps,
+    asset_out: Asset,
+    swap_operations: Vec<SwapOperation>,
+    include_responses: bool,
+) -> ContractResult<(Asset, Vec<ReverseSimulationResponse>)> {
+    let (asset_in, responses) = swap_operations.iter().rev().try_fold(
+        (asset_out, Vec::new()),
+        |(asset_in_needed, mut responses), operation| -> Result<_, ContractError> {
+            let oroswap_ask_asset = asset_in_needed.into_oroswap_asset(deps.api)?;
+
+            let res: ReverseSimulationResponse = deps.querier.query_wasm_smart(
+                &operation.pool,
+                &PairQueryMsg::ReverseSimulation {
+                    offer_asset_info: None,
+                    ask_asset: oroswap_ask_asset,
+                },
+            )?;
+
+            assert_max_spread(res.offer_amount, res.spread_amount)?;
+
+            if include_responses {
+                responses.push(res.clone());
+            }
+
+            Ok((
+                Asset::new(
+                    deps.api,
+                    &operation.denom_in,
+                    res.offer_amount.checked_add(Uint128::one())?,
+                ),
+                responses,
+            ))
+        },
+    )?;
+
+    Ok((asset_in, responses))
+}
+
+fn simulate_smart_swap_exact_asset_in(
+    deps: Deps,
+    ask_denom: String,
+    routes: Vec<Route>,
+    include_responses: bool,
+) -> ContractResult<(Asset, Vec<Vec<SimulationResponse>>)> {
+    let mut asset_out = Asset::new(deps.api, &ask_denom, Uint128::zero());
+    let mut simulation_responses = Vec::new();
+
+    for route in &routes {
+        let (route_asset_out, route_simulation_responses) = simulate_swap_exact_asset_in(
+            deps,
+            route.offer_asset.clone(),
+            route.operations.clone(),
+            include_responses,
+        )?;
+
+        asset_out.add(route_asset_out.amount())?;
+
+        if include_responses {
+            simulation_responses.push(route_simulation_responses);
+        }
+    }
+
+    Ok((asset_out, simulation_responses))
+}
+
+fn calculate_weighted_spot_price_from_simulation_responses(
+    deps: Deps,
+    asset_in: Asset,
+    routes: Vec<Route>,
+    simulation_responses: Vec<Vec<SimulationResponse>>,
+) -> ContractResult<Decimal> {
+    let spot_price = routes.into_iter().zip(simulation_responses).try_fold(
+        Decimal::zero(),
+        |curr_spot_price, (route, res)| -> ContractResult<Decimal> {
+            let route_spot_price = calculate_spot_price_from_simulation_responses(
+                deps,
+                asset_in.clone(),
+                route.operations,
+                res,
+            )?;
+
+            let weight = Decimal::from_ratio(route.offer_asset.amount(), asset_in.amount());
+
+            Ok(curr_spot_price + (route_spot_price * weight))
+        },
+    )?;
+
+    Ok(spot_price)
+}
+
+fn calculate_spot_price_from_simulation_responses(
+    deps: Deps,
+    asset_in: Asset,
+    swap_operations: Vec<SwapOperation>,
+    simulation_responses: Vec<SimulationResponse>,
+) -> ContractResult<Decimal> {
+    let (_, spot_price) = swap_operations.iter().zip(simulation_responses).try_fold(
+        (asset_in, Decimal::one()),
+        |(asset_out, curr_spot_price), (op, res)| -> Result<_, ContractError> {
+            let amount_out_without_slippage = res
+                .return_amount
+                .checked_add(res.spread_amount)?
+                .checked_add(res.commission_amount)?;
+
+            Ok((
+                Asset::new(deps.api, &op.denom_out, res.return_amount),
+                curr_spot_price.checked_mul(Decimal::from_ratio(
+                    amount_out_without_slippage,
+                    asset_out.amount(),
+                ))?,
+            ))
+        },
+    )?;
+
+    Ok(spot_price)
+}
+
+fn calculate_spot_price_from_reverse_simulation_responses(
+    deps: Deps,
+    asset_out: Asset,
+    swap_operations: Vec<SwapOperation>,
+    reverse_simulation_responses: Vec<ReverseSimulationResponse>,
+) -> ContractResult<Decimal> {
+    let (_, spot_price) = swap_operations
+        .iter()
+        .rev()
+        .zip(reverse_simulation_responses)
+        .try_fold(
+            (asset_out, Decimal::one()),
+            |(asset_in_needed, curr_spot_price), (op, res)| -> Result<_, ContractError> {
+                let amount_out_without_slippage = asset_in_needed
+                    .amount()
+                    .checked_add(res.spread_amount)?
+                    .checked_add(res.commission_amount)?;
+
+                Ok((
+                    Asset::new(
+                        deps.api,
+                        &op.denom_in,
+                        res.offer_amount.checked_add(Uint128::one())?,
+                    ),
+                    curr_spot_price.checked_mul(Decimal::from_ratio(
+                        amount_out_without_slippage,
+                        res.offer_amount,
+                    ))?,
+                ))
+            },
+        )?;
+
+    Ok(spot_price)
+}

--- a/contracts/adapters/swap/oroswap/src/error.rs
+++ b/contracts/adapters/swap/oroswap/src/error.rs
@@ -1,0 +1,38 @@
+use cosmwasm_std::{OverflowError, StdError};
+use skip::error::SkipError;
+use thiserror::Error;
+
+pub type ContractResult<T> = core::result::Result<T, ContractError>;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error(transparent)]
+    Std(#[from] StdError),
+
+    #[error(transparent)]
+    Overflow(#[from] OverflowError),
+
+    #[error(transparent)]
+    Skip(#[from] SkipError),
+
+    #[error(transparent)]
+    Payment(#[from] cw_utils::PaymentError),
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("swap_operations cannot be empty")]
+    SwapOperationsEmpty,
+
+    #[error("coin_in denom must match the first swap operation's denom in")]
+    CoinInDenomMismatch,
+
+    #[error("coin_out denom must match the last swap operation's denom out")]
+    CoinOutDenomMismatch,
+
+    #[error("Operation exceeds max spread limit")]
+    MaxSpreadAssertion,
+
+    #[error("Contract has no balance of offer asset")]
+    NoOfferAssetAmount,
+}

--- a/contracts/adapters/swap/oroswap/src/lib.rs
+++ b/contracts/adapters/swap/oroswap/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod contract;
+pub mod error;
+pub mod state;

--- a/contracts/adapters/swap/oroswap/src/state.rs
+++ b/contracts/adapters/swap/oroswap/src/state.rs
@@ -1,0 +1,4 @@
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
+
+pub const ENTRY_POINT_CONTRACT_ADDRESS: Item<Addr> = Item::new("entry_point_contract_address");

--- a/contracts/adapters/swap/oroswap/tests/test_execute_oroswap_pool_swap.rs
+++ b/contracts/adapters/swap/oroswap/tests/test_execute_oroswap_pool_swap.rs
@@ -1,9 +1,5 @@
 use std::vec;
 
-use oroswap::{
-    asset::{Asset as OroswapAsset, AssetInfo},
-    pair::{Cw20HookMsg as OroswapPairCw20HookMsg, ExecuteMsg as OroswapPairExecuteMsg},
-};
 use cosmwasm_std::{
     testing::{mock_dependencies_with_balances, mock_env, mock_info},
     to_json_binary, Addr, Coin, Decimal, QuerierResult,
@@ -11,6 +7,10 @@ use cosmwasm_std::{
     SubMsg, SystemResult, Uint128, WasmMsg, WasmQuery,
 };
 use cw20::{BalanceResponse, Cw20ExecuteMsg};
+use oroswap::{
+    asset::{Asset as OroswapAsset, AssetInfo},
+    pair::{Cw20HookMsg as OroswapPairCw20HookMsg, ExecuteMsg as OroswapPairExecuteMsg},
+};
 use skip::swap::{ExecuteMsg, SwapOperation};
 use skip_go_swap_adapter_oroswap::error::{ContractError, ContractResult};
 use test_case::test_case;

--- a/contracts/adapters/swap/oroswap/tests/test_execute_oroswap_pool_swap.rs
+++ b/contracts/adapters/swap/oroswap/tests/test_execute_oroswap_pool_swap.rs
@@ -1,0 +1,233 @@
+use std::vec;
+
+use oroswap::{
+    asset::{Asset as OroswapAsset, AssetInfo},
+    pair::{Cw20HookMsg as OroswapPairCw20HookMsg, ExecuteMsg as OroswapPairExecuteMsg},
+};
+use cosmwasm_std::{
+    testing::{mock_dependencies_with_balances, mock_env, mock_info},
+    to_json_binary, Addr, Coin, Decimal, QuerierResult,
+    ReplyOn::Never,
+    SubMsg, SystemResult, Uint128, WasmMsg, WasmQuery,
+};
+use cw20::{BalanceResponse, Cw20ExecuteMsg};
+use skip::swap::{ExecuteMsg, SwapOperation};
+use skip_go_swap_adapter_oroswap::error::{ContractError, ContractResult};
+use test_case::test_case;
+
+/*
+Test Cases:
+
+Expect Success
+    - Native Swap Operation
+    - Cw20 Swap Operation
+
+Expect Error
+    - No Native Offer Asset In Contract Balance To Swap
+    - No Cw20 Offer Asset In Contract Balance To Swap
+    - Unauthorized Caller
+
+ */
+
+// Define test parameters
+struct Params {
+    caller: String,
+    contract_balance: Vec<Coin>,
+    swap_operation: SwapOperation,
+    expected_message: Option<SubMsg>,
+    expected_error: Option<ContractError>,
+}
+
+// Test execute_swap
+#[test_case(
+    Params {
+        caller: "swap_contract_address".to_string(),
+        contract_balance: vec![Coin::new(100, "os")],
+        swap_operation: SwapOperation {
+                pool: "pool_1".to_string(),
+                denom_in: "os".to_string(),
+                denom_out: "ua".to_string(),
+                interface: None,
+            },
+        expected_message: Some(SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "pool_1".to_string(),
+                    msg: to_json_binary(&OroswapPairExecuteMsg::Swap {
+                        offer_asset: OroswapAsset {
+                            info: AssetInfo::NativeToken {
+                                denom: "os".to_string(),
+                            },
+                            amount: Uint128::new(100),
+                        },
+                        ask_asset_info: None,
+                        belief_price: None,
+                        max_spread: Some(Decimal::percent(50)),
+                        to: None,
+                    })?,
+                    funds: vec![Coin::new(100, "os")],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            }),
+        expected_error: None,
+    };
+    "Native Swap Operation")]
+#[test_case(
+    Params {
+        caller: "swap_contract_address".to_string(),
+        contract_balance: vec![],
+        swap_operation: SwapOperation {
+                pool: "pool_1".to_string(),
+                denom_in: "neutron123".to_string(),
+                denom_out: "ua".to_string(),
+                interface: None,
+            },
+        expected_message: Some(SubMsg {
+            id: 0,
+            msg: WasmMsg::Execute {
+                contract_addr: "neutron123".to_string(),
+                msg: to_json_binary(&Cw20ExecuteMsg::Send {
+                    contract: "pool_1".to_string(),
+                    amount: Uint128::from(100u128),
+                    msg: to_json_binary(&OroswapPairCw20HookMsg::Swap {
+                        ask_asset_info: None,
+                        belief_price: None,
+                        max_spread: Some(Decimal::percent(50)),
+                        to: None,
+                    })?,
+                })?,
+                funds: vec![],
+            }.into(),
+            gas_limit: None,
+            reply_on: Never,
+        }),
+        expected_error: None,
+    };
+    "Cw20 Swap Operation")]
+#[test_case(
+    Params {
+        caller: "swap_contract_address".to_string(),
+        contract_balance: vec![],
+        swap_operation: SwapOperation {
+                pool: "pool_1".to_string(),
+                denom_in: "os".to_string(),
+                denom_out: "ua".to_string(),
+                interface: None,
+            },
+        expected_message: None,
+        expected_error: Some(ContractError::NoOfferAssetAmount),
+    };
+    "No Native Offer Asset In Contract Balance To Swap")]
+#[test_case(
+    Params {
+        caller: "swap_contract_address".to_string(),
+        contract_balance: vec![],
+        swap_operation: SwapOperation {
+                pool: "pool_1".to_string(),
+                denom_in: "randomcw20".to_string(),
+                denom_out: "ua".to_string(),
+                interface: None,
+            },
+        expected_message: None,
+        expected_error: Some(ContractError::NoOfferAssetAmount),
+    };
+    "No Cw20 Offer Asset In Contract Balance To Swap")]
+#[test_case(
+    Params {
+        caller: "random".to_string(),
+        contract_balance: vec![
+            Coin::new(100, "un"),
+        ],
+        swap_operation: SwapOperation{
+            pool: "".to_string(),
+            denom_in: "".to_string(),
+            denom_out: "".to_string(),
+            interface: None,
+        },
+        expected_message: None,
+        expected_error: Some(ContractError::Unauthorized),
+    };
+    "Unauthorized Caller - Expect Error")]
+fn test_execute_oroswap_pool_swap(params: Params) -> ContractResult<()> {
+    // Create mock dependencies
+    let mut deps =
+        mock_dependencies_with_balances(&[("swap_contract_address", &params.contract_balance)]);
+
+    // Create mock wasm handler to handle the cw20 balance queries
+    let wasm_handler = |query: &WasmQuery| -> QuerierResult {
+        match query {
+            WasmQuery::Smart { contract_addr, .. } => {
+                if contract_addr == "neutron123" {
+                    SystemResult::Ok(
+                        ContractResult::Ok(
+                            to_json_binary(&BalanceResponse {
+                                balance: Uint128::from(100u128),
+                            })
+                            .unwrap(),
+                        )
+                        .into(),
+                    )
+                } else {
+                    SystemResult::Ok(
+                        ContractResult::Ok(
+                            to_json_binary(&BalanceResponse {
+                                balance: Uint128::from(0u128),
+                            })
+                            .unwrap(),
+                        )
+                        .into(),
+                    )
+                }
+            }
+            _ => panic!("Unsupported query: {:?}", query),
+        }
+    };
+    deps.querier.update_wasm(wasm_handler);
+
+    // Create mock env
+    let mut env = mock_env();
+    env.contract.address = Addr::unchecked("swap_contract_address");
+
+    // Create mock info
+    let info = mock_info(&params.caller, &[]);
+
+    // Call execute_oroswap_pool_swap with the given test parameters
+    let res = skip_go_swap_adapter_oroswap::contract::execute(
+        deps.as_mut(),
+        env,
+        info,
+        ExecuteMsg::OroswapPoolSwap {
+            operation: params.swap_operation,
+        },
+    );
+
+    // Assert the behavior is correct
+    match res {
+        Ok(res) => {
+            // Assert the test did not expect an error
+            assert!(
+                params.expected_error.is_none(),
+                "expected test to error with {:?}, but it succeeded",
+                params.expected_error
+            );
+
+            // Assert the messages are correct
+            assert_eq!(res.messages[0], params.expected_message.unwrap());
+        }
+        Err(err) => {
+            // Assert the test expected an error
+            assert!(
+                params.expected_error.is_some(),
+                "expected test to succeed, but it errored with {:?}",
+                err
+            );
+
+            // Assert the error is correct
+            assert_eq!(err, params.expected_error.unwrap());
+        }
+    }
+
+    Ok(())
+}

--- a/contracts/adapters/swap/oroswap/tests/test_execute_receive.rs
+++ b/contracts/adapters/swap/oroswap/tests/test_execute_receive.rs
@@ -1,0 +1,244 @@
+use core::panic;
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env, mock_info},
+    to_json_binary, Addr, Coin, ContractResult as SystemContractResult, QuerierResult,
+    ReplyOn::Never,
+    SubMsg, SystemResult, Uint128, WasmMsg, WasmQuery,
+};
+use cw20::{BalanceResponse, Cw20Coin, Cw20ReceiveMsg};
+use cw_utils::PaymentError::NonPayable;
+use skip::{
+    asset::Asset,
+    error::SkipError::Payment,
+    swap::{ExecuteMsg, SwapOperation},
+};
+use skip_go_swap_adapter_oroswap::{
+    error::{ContractError, ContractResult},
+    state::ENTRY_POINT_CONTRACT_ADDRESS,
+};
+use test_case::test_case;
+
+/*
+Test Cases:
+
+Expect Success
+    - One Swap Operation - Cw20 In
+    - One Swap Operation - Cw20 In And Out
+
+Expect Error
+    - Coin sent with cw20
+
+ */
+
+// Define test parameters
+struct Params {
+    caller: String,
+    info_funds: Vec<Coin>,
+    sent_asset: Asset,
+    swap_operations: Vec<SwapOperation>,
+    expected_messages: Vec<SubMsg>,
+    expected_error: Option<ContractError>,
+}
+
+// Test execute_swap
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        info_funds: vec![],
+        sent_asset: Asset::Cw20(Cw20Coin {
+            address: "neutron123".to_string(),
+            amount: Uint128::from(100u128)
+        }),
+        swap_operations: vec![
+            SwapOperation {
+                pool: "pool_1".to_string(),
+                denom_in: "neutron123".to_string(),
+                denom_out: "ua".to_string(),
+                interface: None,
+            }
+        ],
+        expected_messages: vec![
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "swap_contract_address".to_string(),
+                    msg: to_json_binary(&ExecuteMsg::OroswapPoolSwap {
+                        operation: SwapOperation {
+                            pool: "pool_1".to_string(),
+                            denom_in: "neutron123".to_string(),
+                            denom_out: "ua".to_string(),
+                            interface: None,
+                        }
+                    })?,
+                    funds: vec![],
+                }.into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "swap_contract_address".to_string(),
+                    msg: to_json_binary(&ExecuteMsg::TransferFundsBack {
+                        return_denom: "ua".to_string(),
+                        swapper: Addr::unchecked("entry_point"),
+                    })?,
+                    funds: vec![],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+        ],
+        expected_error: None,
+    };
+    "One Swap Operation - Cw20 In")]
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        info_funds: vec![],
+        sent_asset: Asset::Cw20(Cw20Coin {
+            address: "neutron123".to_string(),
+            amount: Uint128::from(100u128)
+        }),
+        swap_operations: vec![
+            SwapOperation {
+                pool: "pool_1".to_string(),
+                denom_in: "neutron123".to_string(),
+                denom_out: "neutron987".to_string(),
+                interface: None,
+            }
+        ],
+        expected_messages: vec![
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "swap_contract_address".to_string(),
+                    msg: to_json_binary(&ExecuteMsg::OroswapPoolSwap {
+                        operation: SwapOperation {
+                            pool: "pool_1".to_string(),
+                            denom_in: "neutron123".to_string(),
+                            denom_out: "neutron987".to_string(),
+                            interface: None,
+                        }
+                    })?,
+                    funds: vec![],
+                }.into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "swap_contract_address".to_string(),
+                    msg: to_json_binary(&ExecuteMsg::TransferFundsBack {
+                        return_denom: "neutron987".to_string(),
+                        swapper: Addr::unchecked("entry_point"),
+                    })?,
+                    funds: vec![],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+        ],
+        expected_error: None,
+    };
+    "One Swap Operation - Cw20 In And Out")]
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        info_funds: vec![
+            Coin::new(100, "un"),
+        ],
+        sent_asset: Asset::Cw20(Cw20Coin {
+            address: "neutron123".to_string(),
+            amount: Uint128::from(100u128)
+        }),
+        swap_operations: vec![],
+        expected_messages: vec![],
+        expected_error: Some(ContractError::Skip(Payment(NonPayable{}))),
+    };
+    "Coin sent with cw20 - Expect Error")]
+fn test_execute_swap(params: Params) -> ContractResult<()> {
+    // Create mock dependencies
+    let mut deps = mock_dependencies();
+
+    // Create mock wasm handler to handle the swap adapter contract query
+    let wasm_handler = |query: &WasmQuery| -> QuerierResult {
+        match query {
+            WasmQuery::Smart { contract_addr, .. } => {
+                if contract_addr == "neutron123" {
+                    SystemResult::Ok(SystemContractResult::Ok(
+                        to_json_binary(&BalanceResponse {
+                            balance: Uint128::from(100u128),
+                        })
+                        .unwrap(),
+                    ))
+                } else {
+                    panic!("Unsupported contract: {:?}", query);
+                }
+            }
+            _ => panic!("Unsupported query: {:?}", query),
+        }
+    };
+
+    // Update querier with mock wasm handler
+    deps.querier.update_wasm(wasm_handler);
+
+    // Create mock env
+    let mut env = mock_env();
+    env.contract.address = Addr::unchecked("swap_contract_address");
+
+    // Convert info funds vector into a slice of Coin objects
+    let info_funds: &[Coin] = &params.info_funds;
+
+    // Create mock info with entry point contract address
+    let info = mock_info(params.sent_asset.denom(), info_funds);
+
+    // Store the entry point contract address
+    ENTRY_POINT_CONTRACT_ADDRESS.save(deps.as_mut().storage, &Addr::unchecked("entry_point"))?;
+
+    // Call execute_swap with the given test parameters
+    let res = skip_go_swap_adapter_oroswap::contract::execute(
+        deps.as_mut(),
+        env,
+        info,
+        ExecuteMsg::Receive(Cw20ReceiveMsg {
+            sender: params.caller,
+            amount: params.sent_asset.amount(),
+            msg: to_json_binary(&ExecuteMsg::Swap {
+                operations: params.swap_operations,
+            })
+            .unwrap(),
+        }),
+    );
+
+    // Assert the behavior is correct
+    match res {
+        Ok(res) => {
+            // Assert the test did not expect an error
+            assert!(
+                params.expected_error.is_none(),
+                "expected test to error with {:?}, but it succeeded",
+                params.expected_error
+            );
+
+            // Assert the messages are correct
+            assert_eq!(res.messages, params.expected_messages);
+        }
+        Err(err) => {
+            // Assert the test expected an error
+            assert!(
+                params.expected_error.is_some(),
+                "expected test to succeed, but it errored with {:?}",
+                err
+            );
+
+            // Assert the error is correct
+            assert_eq!(err, params.expected_error.unwrap());
+        }
+    }
+
+    Ok(())
+}

--- a/contracts/adapters/swap/oroswap/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/oroswap/tests/test_execute_swap.rs
@@ -1,0 +1,253 @@
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env, mock_info},
+    to_json_binary, Addr, Coin,
+    ReplyOn::Never,
+    SubMsg, WasmMsg,
+};
+use skip::swap::{ExecuteMsg, SwapOperation};
+use skip_go_swap_adapter_oroswap::{
+    error::{ContractError, ContractResult},
+    state::ENTRY_POINT_CONTRACT_ADDRESS,
+};
+use test_case::test_case;
+
+/*
+Test Cases:
+
+Expect Success
+    - One Swap Operation
+    - Multiple Swap Operations
+    - No Swap Operations (This is prevented in the entry point contract; and will not add any swap messages to the response)
+
+Expect Error
+    - Unauthorized Caller (Only the stored entry point contract can call this function)
+    - No Coin Sent
+    - More Than One Coin Sent
+
+ */
+
+// Define test parameters
+struct Params {
+    caller: String,
+    info_funds: Vec<Coin>,
+    swap_operations: Vec<SwapOperation>,
+    expected_messages: Vec<SubMsg>,
+    expected_error: Option<ContractError>,
+}
+
+// Test execute_swap
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        info_funds: vec![Coin::new(100, "os")],
+        swap_operations: vec![
+            SwapOperation {
+                pool: "pool_1".to_string(),
+                denom_in: "os".to_string(),
+                denom_out: "ua".to_string(),
+                interface: None,
+            }
+        ],
+        expected_messages: vec![
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "swap_contract_address".to_string(),
+                    msg: to_json_binary(&ExecuteMsg::OroswapPoolSwap {
+                        operation: SwapOperation {
+                            pool: "pool_1".to_string(),
+                            denom_in: "os".to_string(),
+                            denom_out: "ua".to_string(),
+                            interface: None,
+                        }
+                    })?,
+                    funds: vec![],
+                }.into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "swap_contract_address".to_string(),
+                    msg: to_json_binary(&ExecuteMsg::TransferFundsBack {
+                        return_denom: "ua".to_string(),
+                        swapper: Addr::unchecked("entry_point"),
+                    })?,
+                    funds: vec![],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+        ],
+        expected_error: None,
+    };
+    "One Swap Operation")]
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        info_funds: vec![Coin::new(100, "os")],
+        swap_operations: vec![
+            SwapOperation {
+                pool: "pool_1".to_string(),
+                denom_in: "os".to_string(),
+                denom_out: "ua".to_string(),
+                interface: None,
+            },
+            SwapOperation {
+                pool: "pool_2".to_string(),
+                denom_in: "ua".to_string(),
+                denom_out: "un".to_string(),
+                interface: None,
+            }
+        ],
+        expected_messages: vec![
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "swap_contract_address".to_string(),
+                    msg: to_json_binary(&ExecuteMsg::OroswapPoolSwap {
+                        operation: SwapOperation {
+                            pool: "pool_1".to_string(),
+                            denom_in: "os".to_string(),
+                            denom_out: "ua".to_string(),
+                            interface: None,
+                        }
+                    })?,
+                    funds: vec![],
+                }.into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "swap_contract_address".to_string(),
+                    msg: to_json_binary(&ExecuteMsg::OroswapPoolSwap {
+                        operation: SwapOperation {
+                            pool: "pool_2".to_string(),
+                            denom_in: "ua".to_string(),
+                            denom_out: "un".to_string(),
+                            interface: None,
+                        }
+                    })?,
+                    funds: vec![],
+                }.into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "swap_contract_address".to_string(),
+                    msg: to_json_binary(&ExecuteMsg::TransferFundsBack {
+                        return_denom: "un".to_string(),
+                        swapper: Addr::unchecked("entry_point"),
+                    })?,
+                    funds: vec![],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+        ],
+        expected_error: None,
+    };
+    "Multiple Swap Operations")]
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        info_funds: vec![Coin::new(100, "os")],
+        swap_operations: vec![],
+        expected_messages: vec![],
+        expected_error: Some(ContractError::SwapOperationsEmpty),
+    };
+    "No Swap Operations")]
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        info_funds: vec![],
+        swap_operations: vec![],
+        expected_messages: vec![],
+        expected_error: Some(ContractError::Payment(cw_utils::PaymentError::NoFunds{})),
+    };
+    "No Coin Sent - Expect Error")]
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        info_funds: vec![
+            Coin::new(100, "un"),
+            Coin::new(100, "os"),
+        ],
+        swap_operations: vec![],
+        expected_messages: vec![],
+        expected_error: Some(ContractError::Payment(cw_utils::PaymentError::MultipleDenoms{})),
+    };
+    "More Than One Coin Sent - Expect Error")]
+#[test_case(
+    Params {
+        caller: "random".to_string(),
+        info_funds: vec![
+            Coin::new(100, "un"),
+        ],
+        swap_operations: vec![],
+        expected_messages: vec![],
+        expected_error: Some(ContractError::Unauthorized),
+    };
+    "Unauthorized Caller - Expect Error")]
+fn test_execute_swap(params: Params) -> ContractResult<()> {
+    // Create mock dependencies
+    let mut deps = mock_dependencies();
+
+    // Create mock env
+    let mut env = mock_env();
+    env.contract.address = Addr::unchecked("swap_contract_address");
+
+    // Convert info funds vector into a slice of Coin objects
+    let info_funds: &[Coin] = &params.info_funds;
+
+    // Create mock info with entry point contract address
+    let info = mock_info(&params.caller, info_funds);
+
+    // Store the entry point contract address
+    ENTRY_POINT_CONTRACT_ADDRESS.save(deps.as_mut().storage, &Addr::unchecked("entry_point"))?;
+
+    // Call execute_swap with the given test parameters
+    let res = skip_go_swap_adapter_oroswap::contract::execute(
+        deps.as_mut(),
+        env,
+        info,
+        ExecuteMsg::Swap {
+            operations: params.swap_operations.clone(),
+        },
+    );
+
+    // Assert the behavior is correct
+    match res {
+        Ok(res) => {
+            // Assert the test did not expect an error
+            assert!(
+                params.expected_error.is_none(),
+                "expected test to error with {:?}, but it succeeded",
+                params.expected_error
+            );
+
+            // Assert the messages are correct
+            assert_eq!(res.messages, params.expected_messages);
+        }
+        Err(err) => {
+            // Assert the test expected an error
+            assert!(
+                params.expected_error.is_some(),
+                "expected test to succeed, but it errored with {:?}",
+                err
+            );
+
+            // Assert the error is correct
+            assert_eq!(err, params.expected_error.unwrap());
+        }
+    }
+
+    Ok(())
+}

--- a/contracts/adapters/swap/oroswap/tests/test_execute_transfer_funds_back.rs
+++ b/contracts/adapters/swap/oroswap/tests/test_execute_transfer_funds_back.rs
@@ -1,0 +1,167 @@
+use cosmwasm_std::{
+    testing::{mock_dependencies_with_balances, mock_env, mock_info},
+    Addr, BankMsg, Coin,
+    ReplyOn::Never,
+    SubMsg,
+};
+use skip::{error::SkipError, swap::ExecuteMsg};
+use skip_go_swap_adapter_oroswap::error::{ContractError, ContractResult};
+use test_case::test_case;
+
+/*
+Test Cases:
+
+Expect Success
+    - One Coin Balance
+    - Multiple Coin Balance
+    - No Coin Balance (This will fail at the bank module if attempted)
+
+Expect Error
+    - Unauthorized Caller (Only contract itself can call this function)
+ */
+
+// Define test parameters
+struct Params {
+    caller: String,
+    contract_balance: Vec<Coin>,
+    return_denom: String,
+    expected_messages: Vec<SubMsg>,
+    expected_error: Option<ContractError>,
+}
+
+// Test execute_transfer_funds_back
+#[test_case(
+    Params {
+        caller: "swap_contract_address".to_string(),
+        contract_balance: vec![Coin::new(100, "os")],
+        return_denom: "os".to_string(),
+        expected_messages: vec![
+            SubMsg {
+                id: 0,
+                msg: BankMsg::Send {
+                    to_address: "swapper".to_string(),
+                    amount: vec![Coin::new(100, "os")],
+                }.into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+        ],
+        expected_error: None,
+    };
+    "Transfers One Coin Balance")]
+#[test_case(
+    Params {
+        caller: "swap_contract_address".to_string(),
+        contract_balance: vec![
+            Coin::new(100, "os"),
+            Coin::new(100, "uatom"),
+        ],
+        return_denom: "os".to_string(),
+        expected_messages: vec![
+            SubMsg {
+                id: 0,
+                msg: BankMsg::Send {
+                    to_address: "swapper".to_string(),
+                    amount: vec![
+                        Coin::new(100, "os"),
+                        Coin::new(100, "uatom")
+                    ],
+                }.into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+        ],
+        expected_error: None,
+    };
+    "Transfers Multiple Coin Balance")]
+#[test_case(
+    Params {
+        caller: "swap_contract_address".to_string(),
+        contract_balance: vec![],
+        return_denom: "os".to_string(),
+        expected_messages: vec![
+            SubMsg {
+                id: 0,
+                msg: BankMsg::Send {
+                    to_address: "swapper".to_string(),
+                    amount: vec![],
+                }.into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+        ],
+        expected_error: None,
+    };
+    "Transfers No Coin Balance")]
+#[test_case(
+    Params {
+        caller: "random".to_string(),
+        contract_balance: vec![],
+        return_denom: "os".to_string(),
+        expected_messages: vec![
+            SubMsg {
+                id: 0,
+                msg: BankMsg::Send {
+                    to_address: "swapper".to_string(),
+                    amount: vec![],
+                }.into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+        ],
+        expected_error: Some(ContractError::Skip(SkipError::Unauthorized)),
+    };
+    "Unauthorized Caller")]
+fn test_execute_transfer_funds_back(params: Params) -> ContractResult<()> {
+    // Convert params contract balance to a slice
+    let contract_balance: &[Coin] = &params.contract_balance;
+
+    // Create mock dependencies
+    let mut deps = mock_dependencies_with_balances(&[("swap_contract_address", contract_balance)]);
+
+    // Create mock env
+    let mut env = mock_env();
+    env.contract.address = Addr::unchecked("swap_contract_address");
+
+    // Create mock info
+    let info = mock_info(&params.caller, &[]);
+
+    // Call execute_swap with the given test parameters
+    let res = skip_go_swap_adapter_oroswap::contract::execute(
+        deps.as_mut(),
+        env,
+        info,
+        ExecuteMsg::TransferFundsBack {
+            return_denom: params.return_denom,
+            swapper: Addr::unchecked("swapper"),
+        },
+    );
+
+    // Assert the behavior is correct
+    match res {
+        Ok(res) => {
+            // Assert the test did not expect an error
+            assert!(
+                params.expected_error.is_none(),
+                "expected test to error with {:?}, but it succeeded",
+                params.expected_error
+            );
+
+            // Assert the messages are correct
+            assert_eq!(res.messages, params.expected_messages);
+        }
+        Err(err) => {
+            // Assert the test expected an error
+            assert!(
+                params.expected_error.is_some(),
+                "expected test to succeed, but it errored with {:?}",
+                err
+            );
+
+            // Assert the error is correct
+            assert_eq!(err, params.expected_error.unwrap());
+        }
+    }
+
+    Ok(())
+}

--- a/deployed-contracts/zigchain/testnet.toml
+++ b/deployed-contracts/zigchain/testnet.toml
@@ -1,0 +1,46 @@
+[info]
+chain_id = "zig-test-2"
+network = "testnet"
+deploy_date = "20/05/2026 14:52:22"
+commit_hash = "82173335c70b90e43e2e0a265dbd0b3a91889ad5"
+salt = "2"
+
+[checksums]
+"skip_go_entry_point.wasm" = "fd62732d9c41d18718d5fdd06974e0e1d0e42f940eec69a2332122382a8ec489"
+"skip_go_hyperlane_adapter.wasm" = "efcc141a17f949563313a12e56293ed3dac1c7c2ed30439e057bb85acfc6f251"
+"skip_go_ibc_adapter_ibc_callbacks.wasm" = "bd0c5a9692232d4a79f56d92ba768a4132d10108d358315bc9c48a3168d0eea2"
+"skip_go_ibc_adapter_ibc_hooks.wasm" = "ca566c8c7ab09f933947beb5fc69f7044ffb8c306c2f7df9c0f93fb2a78bfdac"
+"skip_go_ibc_adapter_neutron_transfer.wasm" = "30c24a2834d13fac85c12757083e6c51eae73c82bda0dbfba8f43982803ea34a"
+"skip_go_placeholder.wasm" = "90f301ade9311d389d3a3cafbacba26a71997988844c1c952b180f5881013bad"
+"skip_go_swap_adapter_astroport.wasm" = "6505d6d0575a7ddb9232e3bf5b74d60f589087f0c29d666b863c99e7de03bded"
+"skip_go_swap_adapter_astrovault.wasm" = "75a0845ef0b4aad6eb7d8184e33e75346d509cfe57cd3d813e556f7f5b016832"
+"skip_go_swap_adapter_dexter.wasm" = "331c474af94b8ebce7637820e8ceb46d86261c79771ad2b61b619816712be8cd"
+"skip_go_swap_adapter_drop.wasm" = "c6cb2c20ab866fd452ae088828d6884597ce70e1ab39ec3d8e1affcc2368d8d4"
+"skip_go_swap_adapter_duality.wasm" = "4d08a5fb89f72954cc4b654da21af52fda21c0d8891e8d2297b4de5244b33dcb"
+"skip_go_swap_adapter_elys_amm.wasm" = "5743526fb14a3d9f1d58698a262f71198d06fd38e42ad3b64f06364d26615c68"
+"skip_go_swap_adapter_hallswap.wasm" = "d62ff6a3eee0ec63185ee85411c640a8bb4e61e77ca59c0afc0f5cd7d5e99fb9"
+"skip_go_swap_adapter_injective.wasm" = "b54f4a8e002fbe72843da94c2de07955469b17a2665fade618dbb0e16d8f873b"
+"skip_go_swap_adapter_lido_satellite.wasm" = "37e4152a29f2fdb2ac70779efc9a98054a631e76596793d24a130d1daf372284"
+"skip_go_swap_adapter_mantra_dex.wasm" = "a9d2df254503a321525d9c5d61d85d59697afdd9cf993ed3d0f94afa8de273c2"
+"skip_go_swap_adapter_oroswap.wasm" = "cbc629a4d1acf73315c0c6a36db4df6be5303410e9b5afc29d8d3e8f3489237b"
+"skip_go_swap_adapter_osmosis_poolmanager.wasm" = "f369b69fbbab8de40bfaaf40b05cf8b37289274417115857f12a1c0bd41242c6"
+"skip_go_swap_adapter_pryzm.wasm" = "e91dfec8d60df0e0fab579746c55d8970475e74bbb6e7fa9df97fece81826b74"
+"skip_go_swap_adapter_white_whale.wasm" = "6842e9b8fd69bab07e91283b0902f8dd296f79377a858ef7e87555f4bf1a50d6"
+
+[code-ids]
+ibc_transfer_adapter_contract_code_id = "2264"
+swap_adapter_testnet-zigchain-oroswap_contract_code_id = "2265"
+entry_point_contract_code_id = "2266"
+
+[contract-addresses]
+ibc_transfer_adapter_contract_address = "zig1xa28p6mdmmczsf7m3zs4mwszn0ddvrqyl3yyaprdsll0fqfxr72s74jq49"
+swap_adapter_testnet-zigchain-oroswap_contract_address = "zig15mvjeujsv89u2sz4jfyk35crfg3zga8wjp52rcvhk4jjrwnxs66sczsqp4"
+entry_point_contract_address = "zig14fyw9d085z2hlhun27xdm9dmvqmmvjkdm7pm3gzy56ufjpj3f84qql4zp7"
+
+[tx-hashes]
+store_ibc_transfer_adapter_tx_hash = "361ec577c2eee9242382f3bdc6f57c85a28902c4923865c32067c8f5a0a178c0"
+instantiate_ibc_transfer_adapter_tx_hash = "5cb6a2a42b7b33a660c1cf9a2e2010ec50bb740986dfe0c02fc0aec72a8501bd"
+store_swap_adapter_testnet-zigchain-oroswap_tx_hash = "f272faba81364705235c66410ff1568cd7c892c464f8b24fc17498736ff3429d"
+instantiate_swap_adapter_testnet-zigchain-oroswap_tx_hash = "cf1bc346035350bf949d1e2fae6b9fb758a56d4b57d93a23ff6a30e06cdafba5"
+store_entry_point_tx_hash = "5a4a93f61eab313475ce1193ca5d244d31056799ea0cb1674bb6cdb6104d317d"
+instantiate_entry_point_tx_hash = "3dbdbc123df456ea02f91ab6b0d0bf5a1f5a4a19396024e3d17e6b04faa03857"

--- a/packages/skip/Cargo.toml
+++ b/packages/skip/Cargo.toml
@@ -16,6 +16,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 astroport           = { workspace = true }
+oroswap             = { workspace = true }
 cosmos-sdk-proto    = { workspace = true }
 cosmwasm-schema     = { workspace = true }
 cosmwasm-std        = { workspace = true }

--- a/packages/skip/src/asset.rs
+++ b/packages/skip/src/asset.rs
@@ -1,5 +1,6 @@
 use crate::error::SkipError;
 use astroport::asset::{Asset as AstroportAsset, AssetInfo};
+use oroswap::asset::{Asset as OroswapAsset, AssetInfo as OroswapAssetInfo};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     to_json_binary, Api, BankMsg, Binary, Coin, CosmosMsg, DepsMut, Env, MessageInfo, Uint128,
@@ -143,6 +144,23 @@ impl Asset {
             }),
             Asset::Cw20(cw20_coin) => Ok(AstroportAsset {
                 info: AssetInfo::Token {
+                    contract_addr: api.addr_validate(&cw20_coin.address)?,
+                },
+                amount: cw20_coin.amount,
+            }),
+        }
+    }
+
+    pub fn into_oroswap_asset(&self, api: &dyn Api) -> Result<OroswapAsset, SkipError> {
+        match self {
+            Asset::Native(coin) => Ok(OroswapAsset {
+                info: OroswapAssetInfo::NativeToken {
+                    denom: coin.denom.clone(),
+                },
+                amount: coin.amount,
+            }),
+            Asset::Cw20(cw20_coin) => Ok(OroswapAsset {
+                info: OroswapAssetInfo::Token {
                     contract_addr: api.addr_validate(&cw20_coin.address)?,
                 },
                 amount: cw20_coin.amount,

--- a/packages/skip/src/asset.rs
+++ b/packages/skip/src/asset.rs
@@ -1,6 +1,5 @@
 use crate::error::SkipError;
 use astroport::asset::{Asset as AstroportAsset, AssetInfo};
-use oroswap::asset::{Asset as OroswapAsset, AssetInfo as OroswapAssetInfo};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     to_json_binary, Api, BankMsg, Binary, Coin, CosmosMsg, DepsMut, Env, MessageInfo, Uint128,
@@ -8,6 +7,7 @@ use cosmwasm_std::{
 };
 use cw20::{Cw20Coin, Cw20CoinVerified, Cw20Contract, Cw20ExecuteMsg};
 use cw_utils::{nonpayable, one_coin};
+use oroswap::asset::{Asset as OroswapAsset, AssetInfo as OroswapAssetInfo};
 use white_whale_std::pool_network::asset::{
     Asset as WhiteWhaleAsset, AssetInfo as WhiteWhaleAssetInfo,
 };

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -98,6 +98,7 @@ pub enum ExecuteMsg {
     Swap { operations: Vec<SwapOperation> },
     TransferFundsBack { swapper: Addr, return_denom: String },
     AstroportPoolSwap { operation: SwapOperation }, // Only used for the astroport swap adapter contract
+    OroswapPoolSwap { operation: SwapOperation },   // Only used for the oroswap swap adapter contract
     WhiteWhalePoolSwap { operation: SwapOperation }, // Only used for the white whale swap adapter contract
 }
 

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -98,7 +98,7 @@ pub enum ExecuteMsg {
     Swap { operations: Vec<SwapOperation> },
     TransferFundsBack { swapper: Addr, return_denom: String },
     AstroportPoolSwap { operation: SwapOperation }, // Only used for the astroport swap adapter contract
-    OroswapPoolSwap { operation: SwapOperation },   // Only used for the oroswap swap adapter contract
+    OroswapPoolSwap { operation: SwapOperation }, // Only used for the oroswap swap adapter contract
     WhiteWhalePoolSwap { operation: SwapOperation }, // Only used for the white whale swap adapter contract
 }
 

--- a/scripts/configs/zigchain.toml
+++ b/scripts/configs/zigchain.toml
@@ -1,0 +1,32 @@
+# Enter your mnemonic here
+MNEMONIC = "<YOUR MNEMONIC HERE>"
+
+# Commit Hash of the commit used to build the contracts
+COMMIT_HASH = "<COMMIT HASH HERE>"
+
+MAINNET_REST_URL = "https://api.zigchain.com"
+MAINNET_RPC_URL = "https://rpc.zigchain.com"
+MAINNET_CHAIN_ID = "zig-1"
+
+TESTNET_REST_URL = "https://testnet-api.zigchain.com"
+TESTNET_RPC_URL = "https://testnet-rpc.zigchain.com"
+TESTNET_CHAIN_ID = "zig-test-2"
+
+ADDRESS_PREFIX = "zig"
+DENOM = "uzig"
+GAS_PRICE = 0.025
+
+# Contract Paths (arm64 for Apple Silicon, remove -aarch64 suffix for x86)
+ENTRY_POINT_CONTRACT_PATH = "../artifacts/skip_go_entry_point-aarch64.wasm"
+IBC_TRANSFER_ADAPTER_PATH = "../artifacts/skip_go_ibc_adapter_ibc_callbacks-aarch64.wasm"
+
+# SALT USED TO GENERATE A DETERMINISTIC ADDRESS
+SALT = "1"
+
+# Pre-compute this with: wasmd q wasm build-address <checksum> <deployer_address> <salt_hex>
+# Or fill in after first deployment and redeploy swap adapter via migrate
+ENTRY_POINT_PRE_GENERATED_ADDRESS = "<PRE GENERATED ADDRESS HERE>"
+
+[[testnet_swap_venues]]
+name = "zigchain-oroswap"
+swap_adapter_path = "../artifacts/skip_go_swap_adapter_oroswap-aarch64.wasm"

--- a/scripts/configs/zigchain.toml
+++ b/scripts/configs/zigchain.toml
@@ -21,12 +21,12 @@ ENTRY_POINT_CONTRACT_PATH = "../artifacts/skip_go_entry_point-aarch64.wasm"
 IBC_TRANSFER_ADAPTER_PATH = "../artifacts/skip_go_ibc_adapter_ibc_callbacks-aarch64.wasm"
 
 # SALT USED TO GENERATE A DETERMINISTIC ADDRESS
-SALT = "1"
+SALT = "2"
 
 # Pre-compute this with: wasmd q wasm build-address <checksum> <deployer_address> <salt_hex>
 # Or fill in after first deployment and redeploy swap adapter via migrate
 ENTRY_POINT_PRE_GENERATED_ADDRESS = "<PRE GENERATED ADDRESS HERE>"
 
 [[testnet_swap_venues]]
-name = "zigchain-oroswap"
-swap_adapter_path = "../artifacts/skip_go_swap_adapter_oroswap-aarch64.wasm"
+name = "testnet-zigchain-oroswap"
+swap_adapter_path = "../artifacts/skip_go_swap_adapter_oroswap.wasm"


### PR DESCRIPTION
> [!NOTE]
> **Testnet only for now.** This PR ships the Oroswap adapter deployed on **Zigchain testnet**. Mainnet deployment is **not** included yet

## Summary
- Add a new Skip swap adapter for **Oroswap**, the DEX on **Zigchain**.
- Add Zigchain network config (`scripts/configs/zigchain.toml`) and deployed-contract records for Zigchain testnet (`deployed-contracts/zigchain/testnet.toml`).
- Register the `oroswap` venue in `packages/skip` (swap venue + asset handling).
- Pin `drop-factory` to a specific revision so the workspace-optimizer `--locked` build is reproducible.

## Details
- New contract: `contracts/adapters/swap/oroswap`
  - Implements the standard Skip swap adapter interface (`execute_swap`, `execute_pool_swap`, `execute_transfer_funds_back`, CW20 `receive` flow).
  - Includes schema binary and unit tests covering swap execution, pool swap, receive entry point, and transfer-funds-back behavior.
- Workspace wiring: added the crate to the root `Cargo.toml`, updated `Cargo.lock`, and added the dependency in `packages/skip/Cargo.toml`.
- Adds README documenting the adapter usage.

### Dependency pin: `drop-factory`
- Switched `drop-factory` from a moving branch ref to a fixed git revision:
  ```diff
  - drop-factory = { git = "...drop-contracts.git", branch = "feat/audit-fixes", ... }
 
## Test plan
- [ ] `cargo build --release --target wasm32-unknown-unknown -p skip-go-swap-adapter-oroswap`
- [ ] `cargo test -p skip-go-swap-adapter-oroswap`
- [ ] Workspace-wide `cargo test` passes
- [ ] Verify deployed addresses in `deployed-contracts/zigchain/testnet.toml` against the on-chain contracts
- [ ] Smoke-test a swap route on Zigchain testnet via the deployed adapter
