### PR TITLE
Add wasmswap swap venue adapter

### DIFF
--- a/contracts/adapters/swap/wasmswap/Cargo.toml
+++ b/contracts/adapters/swap/wasmswap/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name          = "skip-go-swap-adapter-wasmswap"
+version       = { workspace = true }
+rust-version  = { workspace = true }
+authors       = { workspace = true }
+edition       = { workspace = true }
+license       = { workspace = true }
+homepage      = { workspace = true }
+repository    = { workspace = true }
+documentation = { workspace = true }
+keywords      = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+backtraces = ["cosmwasm-std/backtraces"]
+library = []
+
+[dependencies]
+cosmwasm-schema   = { workspace = true }
+cosmwasm-std      = { workspace = true }
+cw2               = { workspace = true }
+cw20              = { workspace = true }
+cw-storage-plus   = { workspace = true }
+cw-utils          = { workspace = true }
+skip              = { workspace = true }
+thiserror         = { workspace = true }
+
+[dev-dependencies]
+serde-json-wasm   = "1.0"

--- a/contracts/adapters/swap/wasmswap/README.md
+++ b/contracts/adapters/swap/wasmswap/README.md
@@ -1,0 +1,78 @@
+# Wasmswap Swap Adapter Contract
+
+The wasmswap swap adapter contract is responsible for:
+
+1. Taking the standardized entry point swap operations message format and converting it to wasmswap pool swap message format.
+2. Swapping by dispatching swaps directly to each wasmswap pool contract in the route.
+3. Providing query methods that can be called by the entry point contract (generally, to any external actor) to simulate multi-hop swaps that specify either an exact amount in or an exact amount out.
+
+Note: Swap adapter contracts expect to be called by an entry point contract that provides basic validation and minimum amount out safety guarantees for the caller. There are no slippage guarantees provided by swap adapter contracts.
+
+WARNING: Do not send funds directly to the contract without calling one of its functions. Funds sent directly to the contract do not trigger any contract logic that performs validation / safety checks (as the Cosmos SDK handles direct fund transfers in the `Bank` module and not the `Wasm` module). There are no explicit recovery mechanisms for accidentally sent funds.
+
+## Protocol notes
+
+Wasmswap (the AMM originally known as JunoSwap) differs from astroport / white-whale style AMMs in two ways that shape this adapter:
+
+1. **There is no cw20 `Send` hook.** A pool pulls cw20 funds with `TransferFrom`, so a cw20 input requires an `IncreaseAllowance` on the token contract before the swap message. Native inputs are attached as funds.
+2. **There is no reverse price query.** The pool only exposes `Token1ForToken2Price` / `Token2ForToken1Price` (exact amount in). `SimulateSwapExactAssetOut` therefore derives the required input from the pool's reserves and fee, inverting the pool's own constant product formula and rounding up.
+
+Each pool has its own fee, which is read per hop from the pool's `Fee` query and converted to basis points (`lp_fee_percent + protocol_fee_percent`).
+
+There is no router contract: every pool is a standalone contract, and `SwapOperation.pool` carries its address.
+
+## InstantiateMsg
+
+Instantiates a new wasmswap swap adapter contract using the entry point contract address provided in the instantiation message.
+
+```json
+{
+  "entry_point_contract_address": "axm1..."
+}
+```
+
+## ExecuteMsg
+
+### `swap`
+
+Swaps the coin sent using the operations provided.
+
+```json
+{
+  "swap": {
+    "operations": [
+      {
+        "pool": "axm1...",
+        "denom_in": "uaxm",
+        "denom_out": "axm1... (cw20 contract address)"
+      }
+    ]
+  }
+}
+```
+
+### `transfer_funds_back`
+
+Transfers all of the contract's balance for the given denom back to the swapper. Can only be called by the contract itself.
+
+### `wasm_swap_pool_swap`
+
+Dispatches a single swap to a wasmswap pool. Can only be called by the contract itself.
+
+## QueryMsg
+
+### `simulate_swap_exact_asset_in`
+
+Returns the asset received from swapping the given asset in through the given operations.
+
+### `simulate_swap_exact_asset_out`
+
+Returns the asset required to receive the given asset out through the given operations.
+
+### `simulate_swap_exact_asset_in_with_metadata` / `simulate_swap_exact_asset_out_with_metadata`
+
+Same as above, optionally including the route's spot price.
+
+### `simulate_smart_swap_exact_asset_in` / `simulate_smart_swap_exact_asset_in_with_metadata`
+
+Returns the asset received from swapping the given asset in over multiple routes.

--- a/contracts/adapters/swap/wasmswap/src/contract.rs
+++ b/contracts/adapters/swap/wasmswap/src/contract.rs
@@ -1,0 +1,550 @@
+use crate::{
+    error::{ContractError, ContractResult},
+    pool::{
+        get_output_price, FeeResponse, InfoResponse, PoolExecuteMsg, PoolQueryMsg,
+        Token1ForToken2PriceResponse, Token2ForToken1PriceResponse, TokenSelect,
+    },
+    state::ENTRY_POINT_CONTRACT_ADDRESS,
+};
+use cosmwasm_std::{
+    entry_point, from_json, to_json_binary, Binary, CosmosMsg, Decimal, Deps, DepsMut, Env,
+    MessageInfo, QuerierWrapper, Response, Uint128, WasmMsg,
+};
+use cw2::set_contract_version;
+use cw20::{Cw20Coin, Cw20ExecuteMsg, Cw20ReceiveMsg};
+use cw_utils::one_coin;
+use skip::{
+    asset::{get_current_asset_available, Asset},
+    swap::{
+        execute_transfer_funds_back, get_ask_denom_for_routes, Cw20HookMsg, ExecuteMsg,
+        InstantiateMsg, MigrateMsg, QueryMsg, Route, SimulateSmartSwapExactAssetInResponse,
+        SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse, SwapOperation,
+    },
+};
+
+const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+///////////////
+/// MIGRATE ///
+///////////////
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> ContractResult<Response> {
+    Ok(Response::new().add_attribute("action", "migrate"))
+}
+
+///////////////////
+/// INSTANTIATE ///
+///////////////////
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> ContractResult<Response> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    let checked_entry_point_contract_address =
+        deps.api.addr_validate(&msg.entry_point_contract_address)?;
+
+    ENTRY_POINT_CONTRACT_ADDRESS.save(deps.storage, &checked_entry_point_contract_address)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "instantiate")
+        .add_attribute(
+            "entry_point_contract_address",
+            checked_entry_point_contract_address.to_string(),
+        ))
+}
+
+/////////////
+// RECEIVE //
+/////////////
+
+// cw20 entry point: the token is sent to this contract via Send, then swapped.
+pub fn receive_cw20(
+    deps: DepsMut,
+    env: Env,
+    mut info: MessageInfo,
+    cw20_msg: Cw20ReceiveMsg,
+) -> ContractResult<Response> {
+    let sent_asset = Asset::Cw20(Cw20Coin {
+        address: info.sender.to_string(),
+        amount: cw20_msg.amount,
+    });
+    sent_asset.validate(&deps, &env, &info)?;
+
+    // Treat the originator of the send as the sender; it is validated below to be
+    // the entry point contract address.
+    info.sender = deps.api.addr_validate(&cw20_msg.sender)?;
+
+    match from_json(&cw20_msg.msg)? {
+        Cw20HookMsg::Swap { operations } => execute_swap(deps, env, info, operations),
+    }
+}
+
+///////////////
+/// EXECUTE ///
+///////////////
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> ContractResult<Response> {
+    match msg {
+        ExecuteMsg::Receive(cw20_msg) => receive_cw20(deps, env, info, cw20_msg),
+        ExecuteMsg::Swap { operations } => {
+            one_coin(&info)?;
+            execute_swap(deps, env, info, operations)
+        }
+        ExecuteMsg::TransferFundsBack {
+            swapper,
+            return_denom,
+        } => Ok(execute_transfer_funds_back(
+            deps,
+            env,
+            info,
+            swapper,
+            return_denom,
+        )?),
+        ExecuteMsg::WasmSwapPoolSwap { operation } => {
+            execute_wasmswap_pool_swap(deps, env, info, operation)
+        }
+        _ => {
+            unimplemented!()
+        }
+    }
+}
+
+fn execute_swap(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    operations: Vec<SwapOperation>,
+) -> ContractResult<Response> {
+    let entry_point_contract_address = ENTRY_POINT_CONTRACT_ADDRESS.load(deps.storage)?;
+
+    // Only the entry point contract may call the adapter.
+    if info.sender != entry_point_contract_address {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let mut response: Response = Response::new().add_attribute("action", "execute_swap");
+
+    // Each hop is a separate self-call so that at swap time the contract knows
+    // the actual balance produced by the previous hop.
+    for operation in &operations {
+        let swap_msg = WasmMsg::Execute {
+            contract_addr: env.contract.address.to_string(),
+            msg: to_json_binary(&ExecuteMsg::WasmSwapPoolSwap {
+                operation: operation.clone(),
+            })?,
+            funds: vec![],
+        };
+        response = response.add_message(swap_msg);
+    }
+
+    let return_denom = match operations.last() {
+        Some(last_op) => last_op.denom_out.clone(),
+        None => return Err(ContractError::SwapOperationsEmpty),
+    };
+
+    let transfer_funds_back_msg = WasmMsg::Execute {
+        contract_addr: env.contract.address.to_string(),
+        msg: to_json_binary(&ExecuteMsg::TransferFundsBack {
+            swapper: entry_point_contract_address,
+            return_denom,
+        })?,
+        funds: vec![],
+    };
+
+    Ok(response
+        .add_message(transfer_funds_back_msg)
+        .add_attribute("action", "dispatch_swaps_and_transfer_back"))
+}
+
+fn execute_wasmswap_pool_swap(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    operation: SwapOperation,
+) -> ContractResult<Response> {
+    // Self-call only, external callers are rejected.
+    if info.sender != env.contract.address {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let offer_asset = get_current_asset_available(&deps, &env, &operation.denom_in)?;
+
+    if offer_asset.amount().is_zero() {
+        return Err(ContractError::NoOfferAssetAmount);
+    }
+
+    let input_token = input_token_select(&deps.querier, &operation.pool, &operation.denom_in)?;
+
+    // Slippage is enforced by the entry point over the whole route,
+    // so the per-hop minimum is set to the smallest possible value.
+    let swap_msg = to_json_binary(&PoolExecuteMsg::Swap {
+        input_token,
+        input_amount: offer_asset.amount(),
+        min_output: Uint128::one(),
+        expiration: None,
+    })?;
+
+    let msgs: Vec<CosmosMsg> = match &offer_asset {
+        Asset::Native(coin) => vec![WasmMsg::Execute {
+            contract_addr: operation.pool.clone(),
+            msg: swap_msg,
+            funds: vec![coin.clone()],
+        }
+        .into()],
+        // wasmswap has no cw20 Send hook: the pool does a TransferFrom itself,
+        // so an allowance for the exact amount is granted first.
+        Asset::Cw20(coin) => vec![
+            WasmMsg::Execute {
+                contract_addr: coin.address.clone(),
+                msg: to_json_binary(&Cw20ExecuteMsg::IncreaseAllowance {
+                    spender: operation.pool.clone(),
+                    amount: coin.amount,
+                    expires: None,
+                })?,
+                funds: vec![],
+            }
+            .into(),
+            WasmMsg::Execute {
+                contract_addr: operation.pool.clone(),
+                msg: swap_msg,
+                funds: vec![],
+            }
+            .into(),
+        ],
+    };
+
+    Ok(Response::new()
+        .add_messages(msgs)
+        .add_attribute("action", "dispatch_wasmswap_pool_swap"))
+}
+
+/////////////
+/// QUERY ///
+/////////////
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
+    match msg {
+        QueryMsg::SimulateSwapExactAssetIn {
+            asset_in,
+            swap_operations,
+        } => to_json_binary(&query_simulate_swap_exact_asset_in(
+            deps,
+            asset_in,
+            swap_operations,
+        )?),
+        QueryMsg::SimulateSwapExactAssetOut {
+            asset_out,
+            swap_operations,
+        } => to_json_binary(&query_simulate_swap_exact_asset_out(
+            deps,
+            asset_out,
+            swap_operations,
+        )?),
+        QueryMsg::SimulateSmartSwapExactAssetIn { asset_in, routes } => to_json_binary(
+            &query_simulate_smart_swap_exact_asset_in(deps, asset_in, routes)?,
+        ),
+        QueryMsg::SimulateSwapExactAssetInWithMetadata {
+            asset_in,
+            swap_operations,
+            include_spot_price,
+        } => to_json_binary(&query_simulate_swap_exact_asset_in_with_metadata(
+            deps,
+            asset_in,
+            swap_operations,
+            include_spot_price,
+        )?),
+        QueryMsg::SimulateSwapExactAssetOutWithMetadata {
+            asset_out,
+            swap_operations,
+            include_spot_price,
+        } => to_json_binary(&query_simulate_swap_exact_asset_out_with_metadata(
+            deps,
+            asset_out,
+            swap_operations,
+            include_spot_price,
+        )?),
+        QueryMsg::SimulateSmartSwapExactAssetInWithMetadata {
+            asset_in,
+            routes,
+            include_spot_price,
+        } => to_json_binary(&query_simulate_smart_swap_exact_asset_in_with_metadata(
+            deps,
+            asset_in,
+            routes,
+            include_spot_price,
+        )?),
+    }
+    .map_err(From::from)
+}
+
+fn query_simulate_swap_exact_asset_in(
+    deps: Deps,
+    asset_in: Asset,
+    swap_operations: Vec<SwapOperation>,
+) -> ContractResult<Asset> {
+    let (asset_out, _) = simulate_swap_exact_asset_in(deps, asset_in, swap_operations, false)?;
+    Ok(asset_out)
+}
+
+fn query_simulate_swap_exact_asset_out(
+    deps: Deps,
+    asset_out: Asset,
+    swap_operations: Vec<SwapOperation>,
+) -> ContractResult<Asset> {
+    let (asset_in, _) = simulate_swap_exact_asset_out(deps, asset_out, swap_operations, false)?;
+    Ok(asset_in)
+}
+
+fn query_simulate_smart_swap_exact_asset_in(
+    deps: Deps,
+    asset_in: Asset,
+    routes: Vec<Route>,
+) -> ContractResult<Asset> {
+    let (asset_out, _) = simulate_smart_swap_exact_asset_in(deps, asset_in, routes, false)?;
+    Ok(asset_out)
+}
+
+fn query_simulate_swap_exact_asset_in_with_metadata(
+    deps: Deps,
+    asset_in: Asset,
+    swap_operations: Vec<SwapOperation>,
+    include_spot_price: bool,
+) -> ContractResult<SimulateSwapExactAssetInResponse> {
+    let (asset_out, spot_price) =
+        simulate_swap_exact_asset_in(deps, asset_in, swap_operations, include_spot_price)?;
+    Ok(SimulateSwapExactAssetInResponse {
+        asset_out,
+        spot_price,
+    })
+}
+
+fn query_simulate_swap_exact_asset_out_with_metadata(
+    deps: Deps,
+    asset_out: Asset,
+    swap_operations: Vec<SwapOperation>,
+    include_spot_price: bool,
+) -> ContractResult<SimulateSwapExactAssetOutResponse> {
+    let (asset_in, spot_price) =
+        simulate_swap_exact_asset_out(deps, asset_out, swap_operations, include_spot_price)?;
+    Ok(SimulateSwapExactAssetOutResponse {
+        asset_in,
+        spot_price,
+    })
+}
+
+fn query_simulate_smart_swap_exact_asset_in_with_metadata(
+    deps: Deps,
+    asset_in: Asset,
+    routes: Vec<Route>,
+    include_spot_price: bool,
+) -> ContractResult<SimulateSmartSwapExactAssetInResponse> {
+    let (asset_out, spot_price) =
+        simulate_smart_swap_exact_asset_in(deps, asset_in, routes, include_spot_price)?;
+    Ok(SimulateSmartSwapExactAssetInResponse {
+        asset_out,
+        spot_price,
+    })
+}
+
+////////////////////////
+/// HELPERS          ///
+////////////////////////
+
+/// Which of the pool's two tokens is the input one.
+fn input_token_select(
+    querier: &QuerierWrapper,
+    pool: &str,
+    denom_in: &str,
+) -> ContractResult<TokenSelect> {
+    let info: InfoResponse = querier.query_wasm_smart(pool, &PoolQueryMsg::Info {})?;
+
+    if info.token1_denom.matches(denom_in) {
+        Ok(TokenSelect::Token1)
+    } else if info.token2_denom.matches(denom_in) {
+        Ok(TokenSelect::Token2)
+    } else {
+        Err(ContractError::PoolDenomMismatch)
+    }
+}
+
+/// Pool reserves ordered as (input, output) for the given direction.
+fn reserves_for_direction(
+    querier: &QuerierWrapper,
+    pool: &str,
+    denom_in: &str,
+) -> ContractResult<(Uint128, Uint128)> {
+    let info: InfoResponse = querier.query_wasm_smart(pool, &PoolQueryMsg::Info {})?;
+
+    let (r_in, r_out) = if info.token1_denom.matches(denom_in) {
+        (info.token1_reserve, info.token2_reserve)
+    } else if info.token2_denom.matches(denom_in) {
+        (info.token2_reserve, info.token1_reserve)
+    } else {
+        return Err(ContractError::PoolDenomMismatch);
+    };
+
+    if r_in.is_zero() || r_out.is_zero() {
+        return Err(ContractError::PoolEmpty);
+    }
+    Ok((r_in, r_out))
+}
+
+fn pool_fee_bps(querier: &QuerierWrapper, pool: &str) -> ContractResult<u128> {
+    let fee: FeeResponse = querier.query_wasm_smart(pool, &PoolQueryMsg::Fee {})?;
+    Ok(fee.total_fee_bps()?)
+}
+
+/// Spot price of a single hop: output per unit of input, fee included.
+fn spot_price_for_op(querier: &QuerierWrapper, op: &SwapOperation) -> ContractResult<Decimal> {
+    let (r_in, r_out) = reserves_for_direction(querier, &op.pool, &op.denom_in)?;
+    let fee_bps = pool_fee_bps(querier, &op.pool)?;
+
+    let price = Decimal::from_ratio(r_out, r_in);
+    let fee_multiplier = Decimal::from_ratio(10_000u128 - fee_bps, 10_000u128);
+    Ok(price * fee_multiplier)
+}
+
+fn simulate_swap_exact_asset_in(
+    deps: Deps,
+    asset_in: Asset,
+    swap_operations: Vec<SwapOperation>,
+    include_spot_price: bool,
+) -> ContractResult<(Asset, Option<Decimal>)> {
+    let (last_denom_out, mut amount) = match swap_operations.last() {
+        Some(last_op) => (last_op.denom_out.clone(), asset_in.amount()),
+        None => return Err(ContractError::SwapOperationsEmpty),
+    };
+
+    // Walk the route asking each pool for its own price, so both fee and
+    // slippage are accounted for exactly as they would be on execution.
+    for op in &swap_operations {
+        let select = input_token_select(&deps.querier, &op.pool, &op.denom_in)?;
+        amount = match select {
+            TokenSelect::Token1 => {
+                let res: Token1ForToken2PriceResponse = deps.querier.query_wasm_smart(
+                    &op.pool,
+                    &PoolQueryMsg::Token1ForToken2Price {
+                        token1_amount: amount,
+                    },
+                )?;
+                res.token2_amount
+            }
+            TokenSelect::Token2 => {
+                let res: Token2ForToken1PriceResponse = deps.querier.query_wasm_smart(
+                    &op.pool,
+                    &PoolQueryMsg::Token2ForToken1Price {
+                        token2_amount: amount,
+                    },
+                )?;
+                res.token1_amount
+            }
+        };
+    }
+
+    let asset_out = Asset::new(deps.api, &last_denom_out, amount);
+
+    let spot_price = if include_spot_price {
+        Some(calculate_spot_price(&deps.querier, &swap_operations)?)
+    } else {
+        None
+    };
+
+    Ok((asset_out, spot_price))
+}
+
+fn simulate_swap_exact_asset_out(
+    deps: Deps,
+    asset_out: Asset,
+    swap_operations: Vec<SwapOperation>,
+    include_spot_price: bool,
+) -> ContractResult<(Asset, Option<Decimal>)> {
+    let first_denom_in = match swap_operations.first() {
+        Some(first_op) => first_op.denom_in.clone(),
+        None => return Err(ContractError::SwapOperationsEmpty),
+    };
+
+    // wasmswap has no reverse price query, so it is computed from reserves and
+    // fee while walking the route backwards.
+    let mut amount = asset_out.amount();
+    for op in swap_operations.iter().rev() {
+        let (r_in, r_out) = reserves_for_direction(&deps.querier, &op.pool, &op.denom_in)?;
+        let fee_bps = pool_fee_bps(&deps.querier, &op.pool)?;
+
+        if amount >= r_out {
+            return Err(ContractError::AssetOutExceedsReserve);
+        }
+        amount = get_output_price(amount, r_in, r_out, fee_bps)?;
+    }
+
+    let asset_in = Asset::new(deps.api, &first_denom_in, amount);
+
+    let spot_price = if include_spot_price {
+        Some(calculate_spot_price(&deps.querier, &swap_operations)?)
+    } else {
+        None
+    };
+
+    Ok((asset_in, spot_price))
+}
+
+fn simulate_smart_swap_exact_asset_in(
+    deps: Deps,
+    asset_in: Asset,
+    routes: Vec<Route>,
+    include_spot_price: bool,
+) -> ContractResult<(Asset, Option<Decimal>)> {
+    let ask_denom = get_ask_denom_for_routes(&routes)?;
+
+    let mut asset_out = Asset::new(deps.api, &ask_denom, Uint128::zero());
+    let mut weighted_price = Decimal::zero();
+
+    for route in &routes {
+        let (route_asset_out, _) = simulate_swap_exact_asset_in(
+            deps,
+            route.offer_asset.clone(),
+            route.operations.clone(),
+            false,
+        )?;
+        asset_out.add(route_asset_out.amount())?;
+
+        if include_spot_price {
+            let route_price = calculate_spot_price(&deps.querier, &route.operations)?;
+            let weight = Decimal::from_ratio(route.offer_asset.amount(), asset_in.amount());
+            weighted_price += route_price * weight;
+        }
+    }
+
+    let spot_price = if include_spot_price {
+        Some(weighted_price)
+    } else {
+        None
+    };
+
+    Ok((asset_out, spot_price))
+}
+
+/// The route's spot price is the product of the per-hop spot prices.
+fn calculate_spot_price(
+    querier: &QuerierWrapper,
+    swap_operations: &[SwapOperation],
+) -> ContractResult<Decimal> {
+    swap_operations
+        .iter()
+        .try_fold(Decimal::one(), |acc, op| -> ContractResult<Decimal> {
+            Ok(acc * spot_price_for_op(querier, op)?)
+        })
+}

--- a/contracts/adapters/swap/wasmswap/src/error.rs
+++ b/contracts/adapters/swap/wasmswap/src/error.rs
@@ -1,0 +1,38 @@
+use cosmwasm_std::{OverflowError, StdError};
+use skip::error::SkipError;
+use thiserror::Error;
+
+pub type ContractResult<T> = core::result::Result<T, ContractError>;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error(transparent)]
+    Std(#[from] StdError),
+
+    #[error(transparent)]
+    Overflow(#[from] OverflowError),
+
+    #[error(transparent)]
+    Skip(#[from] SkipError),
+
+    #[error(transparent)]
+    Payment(#[from] cw_utils::PaymentError),
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("swap_operations cannot be empty")]
+    SwapOperationsEmpty,
+
+    #[error("Contract has no balance of offer asset")]
+    NoOfferAssetAmount,
+
+    #[error("denom_in is not one of the pool's two tokens")]
+    PoolDenomMismatch,
+
+    #[error("pool has no liquidity for the requested direction")]
+    PoolEmpty,
+
+    #[error("requested asset out exceeds the pool's reserve")]
+    AssetOutExceedsReserve,
+}

--- a/contracts/adapters/swap/wasmswap/src/lib.rs
+++ b/contracts/adapters/swap/wasmswap/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod contract;
+pub mod error;
+pub mod pool;
+pub mod state;

--- a/contracts/adapters/swap/wasmswap/src/pool.rs
+++ b/contracts/adapters/swap/wasmswap/src/pool.rs
@@ -1,0 +1,257 @@
+//! Message types of the wasmswap pool contract, plus price math.
+//!
+//! The interface was recovered from the live contract on Axiome (variant lists come
+//! from the contract's own parse errors, field names confirmed by simulation):
+//!   QueryMsg:   balance, info, token1_for_token2_price, token2_for_token1_price, fee
+//!   ExecuteMsg: add_liquidity, remove_liquidity, swap, pass_through_swap,
+//!               swap_and_send_to, update_config, freeze_deposits
+//!
+//! Important difference from astroport/white-whale: wasmswap has NO cw20 Send hook.
+//! A cw20 input goes through increase_allowance + swap (the pool performs the
+//! TransferFrom itself).
+
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Decimal, StdError, StdResult, Uint128, Uint256};
+use cw20::Expiration;
+
+/// Fee scale used by wasmswap: percentages are converted to basis points.
+const FEE_SCALE_FACTOR: u128 = 10_000;
+/// Decimal stores 18 fractional digits, so percent * 100 gives basis points.
+const FEE_DECIMAL_PRECISION: u128 = 10u128.pow(20);
+
+#[cw_serde]
+pub enum Denom {
+    Native(String),
+    Cw20(cosmwasm_std::Addr),
+}
+
+impl Denom {
+    /// In Skip a denom is a string: either a native denom or a cw20 address.
+    pub fn matches(&self, denom: &str) -> bool {
+        match self {
+            Denom::Native(n) => n == denom,
+            Denom::Cw20(addr) => addr.as_str() == denom,
+        }
+    }
+}
+
+/// NOTE: wasmswap expects PascalCase variants (`Token1`/`Token2`), while
+/// `cw_serde` renames everything to snake_case and would emit `token1`.
+/// The pool rejects that with: "unknown variant token1, expected Token1
+/// or Token2", so the variant names are pinned explicitly.
+#[cw_serde]
+pub enum TokenSelect {
+    #[serde(rename = "Token1")]
+    Token1,
+    #[serde(rename = "Token2")]
+    Token2,
+}
+
+#[cw_serde]
+pub enum PoolExecuteMsg {
+    Swap {
+        input_token: TokenSelect,
+        input_amount: Uint128,
+        min_output: Uint128,
+        expiration: Option<Expiration>,
+    },
+}
+
+#[cw_serde]
+pub enum PoolQueryMsg {
+    Info {},
+    Token1ForToken2Price { token1_amount: Uint128 },
+    Token2ForToken1Price { token2_amount: Uint128 },
+    Fee {},
+}
+
+#[cw_serde]
+pub struct InfoResponse {
+    pub token1_reserve: Uint128,
+    pub token1_denom: Denom,
+    pub token2_reserve: Uint128,
+    pub token2_denom: Denom,
+    pub lp_token_supply: Uint128,
+    pub lp_token_address: String,
+}
+
+#[cw_serde]
+pub struct Token1ForToken2PriceResponse {
+    pub token2_amount: Uint128,
+}
+
+#[cw_serde]
+pub struct Token2ForToken1PriceResponse {
+    pub token1_amount: Uint128,
+}
+
+#[cw_serde]
+pub struct FeeResponse {
+    pub owner: Option<String>,
+    pub lp_fee_percent: Decimal,
+    pub protocol_fee_percent: Decimal,
+    pub protocol_fee_recipient: String,
+}
+
+impl FeeResponse {
+    /// Total pool fee in basis points (2% + 0.4% -> 240).
+    pub fn total_fee_bps(&self) -> StdResult<u128> {
+        let sum = self
+            .lp_fee_percent
+            .checked_add(self.protocol_fee_percent)
+            .map_err(|e| StdError::generic_err(e.to_string()))?;
+        Ok(sum.atomics().u128() / (FEE_DECIMAL_PRECISION / FEE_SCALE_FACTOR))
+    }
+}
+
+/// Forward pricing: how much comes out for a given input_amount.
+/// Mirrors wasmswap's own get_input_price exactly.
+pub fn get_input_price(
+    input_amount: Uint128,
+    input_reserve: Uint128,
+    output_reserve: Uint128,
+    fee_bps: u128,
+) -> StdResult<Uint128> {
+    if input_reserve.is_zero() || output_reserve.is_zero() {
+        return Err(StdError::generic_err("pool has no liquidity"));
+    }
+    let fee_reduction = FEE_SCALE_FACTOR
+        .checked_sub(fee_bps)
+        .ok_or_else(|| StdError::generic_err("fee exceeds 100%"))?;
+
+    let input_with_fee = Uint256::from(input_amount) * Uint256::from(fee_reduction);
+    let numerator = input_with_fee * Uint256::from(output_reserve);
+    let denominator =
+        Uint256::from(input_reserve) * Uint256::from(FEE_SCALE_FACTOR) + input_with_fee;
+
+    Uint128::try_from(numerator / denominator).map_err(|e| StdError::generic_err(e.to_string()))
+}
+
+/// Reverse pricing: how much must go in to receive exactly output_amount.
+/// wasmswap exposes no reverse price query, so it is derived from reserves and fee.
+///
+/// From the forward formula:
+///   out = in*(S-f)*R_out / (R_in*S + in*(S-f))
+/// it follows that:
+///   in  = out*R_in*S / ((S-f)*(R_out - out))   plus 1 to round up.
+pub fn get_output_price(
+    output_amount: Uint128,
+    input_reserve: Uint128,
+    output_reserve: Uint128,
+    fee_bps: u128,
+) -> StdResult<Uint128> {
+    if input_reserve.is_zero() || output_reserve.is_zero() {
+        return Err(StdError::generic_err("pool has no liquidity"));
+    }
+    if output_amount >= output_reserve {
+        return Err(StdError::generic_err(
+            "requested output exceeds pool reserve",
+        ));
+    }
+    let fee_reduction = FEE_SCALE_FACTOR
+        .checked_sub(fee_bps)
+        .ok_or_else(|| StdError::generic_err("fee exceeds 100%"))?;
+
+    let numerator = Uint256::from(output_amount)
+        * Uint256::from(input_reserve)
+        * Uint256::from(FEE_SCALE_FACTOR);
+    let denominator = Uint256::from(fee_reduction)
+        * (Uint256::from(output_reserve) - Uint256::from(output_amount));
+
+    let quotient = numerator / denominator;
+    // round up, otherwise the input would fall short of the requested output
+    let result = if quotient * denominator < numerator {
+        quotient + Uint256::one()
+    } else {
+        quotient
+    } + Uint256::one();
+
+    Uint128::try_from(result).map_err(|e| StdError::generic_err(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Fee of the live RIP/AXM pool on Axiome: 2% + 0.4%
+    const FEE: u128 = 240;
+
+    #[test]
+    fn forward_price_matches_pool_formula() {
+        // in=1_000_000, R_in=1_000_000_000, R_out=2_000_000_000
+        let out = get_input_price(
+            Uint128::new(1_000_000),
+            Uint128::new(1_000_000_000),
+            Uint128::new(2_000_000_000),
+            FEE,
+        )
+        .unwrap();
+        // in_with_fee = 1_000_000*9760 = 9_760_000_000
+        // num = 9_760_000_000*2_000_000_000; den = 1_000_000_000*10_000 + 9_760_000_000
+        let expected = (9_760_000_000u128 * 2_000_000_000u128)
+            / (1_000_000_000u128 * 10_000u128 + 9_760_000_000u128);
+        assert_eq!(out.u128(), expected);
+    }
+
+    #[test]
+    fn reverse_price_covers_requested_output() {
+        let r_in = Uint128::new(1_000_000_000);
+        let r_out = Uint128::new(2_000_000_000);
+        for want in [1u128, 1_000, 1_000_000, 123_456_789] {
+            let need = get_output_price(Uint128::new(want), r_in, r_out, FEE).unwrap();
+            let got = get_input_price(need, r_in, r_out, FEE).unwrap();
+            assert!(
+                got.u128() >= want,
+                "wanted {want}, spent {need}, received {got}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_pool_and_excessive_output_are_rejected() {
+        assert!(get_input_price(Uint128::new(1), Uint128::zero(), Uint128::new(1), FEE).is_err());
+        assert!(get_output_price(
+            Uint128::new(2_000_000_000),
+            Uint128::new(1_000_000_000),
+            Uint128::new(2_000_000_000),
+            FEE
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn token_select_serializes_the_way_the_pool_expects() {
+        // the pool accepts strictly "Token1"/"Token2"
+        assert_eq!(
+            serde_json_wasm::to_string(&TokenSelect::Token1).unwrap(),
+            "\"Token1\""
+        );
+        assert_eq!(
+            serde_json_wasm::to_string(&TokenSelect::Token2).unwrap(),
+            "\"Token2\""
+        );
+    }
+
+    #[test]
+    fn fee_is_converted_to_basis_points() {
+        // The live Axiome pool returns exactly these strings:
+        // {"lp_fee_percent":"2","protocol_fee_percent":"0.4"} — these are PERCENTS,
+        // i.e. Decimal("2") means 2%, not 0.02.
+        let fee = FeeResponse {
+            owner: None,
+            lp_fee_percent: "2".parse().unwrap(),
+            protocol_fee_percent: "0.4".parse().unwrap(),
+            protocol_fee_recipient: "axm1".to_string(),
+        };
+        assert_eq!(fee.total_fee_bps().unwrap(), 240);
+
+        // and the degenerate zero-fee case
+        let zero = FeeResponse {
+            owner: None,
+            lp_fee_percent: Decimal::zero(),
+            protocol_fee_percent: Decimal::zero(),
+            protocol_fee_recipient: "axm1".to_string(),
+        };
+        assert_eq!(zero.total_fee_bps().unwrap(), 0);
+    }
+}

--- a/contracts/adapters/swap/wasmswap/src/state.rs
+++ b/contracts/adapters/swap/wasmswap/src/state.rs
@@ -1,0 +1,4 @@
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
+
+pub const ENTRY_POINT_CONTRACT_ADDRESS: Item<Addr> = Item::new("entry_point_contract_address");

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -100,6 +100,7 @@ pub enum ExecuteMsg {
     AstroportPoolSwap { operation: SwapOperation }, // Only used for the astroport swap adapter contract
     OroswapPoolSwap { operation: SwapOperation }, // Only used for the oroswap swap adapter contract
     WhiteWhalePoolSwap { operation: SwapOperation }, // Only used for the white whale swap adapter contract
+    WasmSwapPoolSwap { operation: SwapOperation }, // Only used for the wasmswap swap adapter contract
 }
 
 #[cw_serde]


### PR DESCRIPTION
## Summary

Adds a swap venue adapter for **wasmswap** (the AMM originally known as JunoSwap). It is the DEX running on **Axiome** (`axiome-1`), where all 43 live pools share one code id.

The adapter is already **deployed and exercised on Axiome mainnet**:

| | address |
|---|---|
| entry point | `axm13vwgdq5anzwysrxupljws9fq6w5qgjl4c8wr4n57v5pdl38j996sewd4sw` |
| wasmswap adapter | `axm1ncs9pxgz5fmplhy5els7ctvhranp3h4eknxgh829786fnqh8sats8ral79` |
| venue name | `axiome-wasmswap` |

Both directions were executed end to end against the live RIP/AXM pool, and the amount received matched the simulation **exactly**:

- 2 AXM to 47.1665 RIP ([tx](https://axiomechain.pro/transactions/CAB4F56E1133AE4C9A120359B87ABCE39C75C6553DF61F8718BBC45D09B94B9F))
- 40 RIP to 1.6157 AXM ([tx](https://axiomechain.pro/transactions/E60AC9B48EC86F0517DBCBEA5D4C48A1B4FC47783F06E436293C2C3689199F04))

## Protocol differences handled

wasmswap deviates from the astroport / white-whale shape in ways worth calling out for review:

1. **No cw20 `Send` hook.** The pool pulls funds with `TransferFrom`, so a cw20 input emits an `IncreaseAllowance` on the token contract before the swap message. Native inputs are attached as funds. That is why `Asset::into_wasm_msg` is not used here.
2. **No reverse price query.** The pool only offers `Token1ForToken2Price` / `Token2ForToken1Price` (exact amount in). `SimulateSwapExactAssetOut` therefore inverts the constant product formula from the pool reserves and fee, rounding up so the result never falls short.
3. **Per pool fees.** Seven distinct fee rates are live on Axiome (0.12% to 3.6%), so the fee is read from each pool `Fee` query per hop rather than assumed. Note the pool returns fees as percents (`"2"` means 2%, not 0.02).
4. **No router.** Every pool is standalone; `SwapOperation.pool` carries its address.

The forward math was cross checked against live pools at all seven fee rates and matched the contract byte for byte.

## Changes

- `contracts/adapters/swap/wasmswap/` — new adapter, with unit tests for the pricing math and for `TokenSelect` serialization (the pool expects `Token1`/`Token2`, while `cw_serde` would emit `token1`).
- `packages/skip/src/swap.rs` — adds the `WasmSwapPoolSwap` self call variant, following the existing per venue pattern.

## Note for maintainers

Axiome does not enable the `stargate` capability in wasmd, so contracts requiring it are rejected there. `entry_point` itself does not use stargate; the requirement is inherited transitively from other venue SDK crates in `packages/skip` (`oroswap-core`, `osmosis-std`, `elys-std`, `neutron-proto`). Feature gating those dependencies would let the entry point build for chains without stargate. Happy to open a separate PR for that if it is something you would take.
